### PR TITLE
feat: Add monthly and yearly statistics reports

### DIFF
--- a/scripts/phase4_render_reports.py
+++ b/scripts/phase4_render_reports.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""
+Phase 4: Render reports.
+
+Generates monthly and yearly statistics reports in HTML, TXT, and JSON
+formats for both repeater and companion nodes.
+
+Output structure:
+    out/reports/
+        index.html                 # Reports listing
+        repeater/
+            2025/
+                index.html         # Yearly report (HTML)
+                report.txt         # Yearly report (TXT)
+                report.json        # Yearly report (JSON)
+                12/
+                    index.html     # Monthly report (HTML)
+                    report.txt     # Monthly report (TXT)
+                    report.json    # Monthly report (JSON)
+        companion/
+            ...                    # Same structure
+"""
+
+import calendar
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+# Add src to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from meshmon.env import get_config
+from meshmon import log
+
+
+def safe_write(path: Path, content: str) -> bool:
+    """Write content to file with error handling.
+
+    Args:
+        path: File path to write to
+        content: Content to write
+
+    Returns:
+        True if write succeeded, False otherwise
+    """
+    try:
+        path.write_text(content)
+        return True
+    except IOError as e:
+        log.err(f"Failed to write {path}: {e}")
+        return False
+from meshmon.reports import (
+    LocationInfo,
+    MonthlyAggregate,
+    YearlyAggregate,
+    aggregate_monthly,
+    aggregate_yearly,
+    format_monthly_txt,
+    format_yearly_txt,
+    get_available_periods,
+    monthly_to_json,
+    yearly_to_json,
+)
+from meshmon.html import render_report_page, render_reports_index
+
+
+def get_node_name(role: str) -> str:
+    """Get display name for a node role from configuration."""
+    cfg = get_config()
+    if role == "repeater":
+        return cfg.repeater_display_name
+    elif role == "companion":
+        return cfg.companion_display_name
+    return role.capitalize()
+
+
+def get_location() -> LocationInfo:
+    """Get location info from config."""
+    cfg = get_config()
+    return LocationInfo(
+        name=cfg.report_location_name,
+        lat=cfg.report_lat,
+        lon=cfg.report_lon,
+        elev=cfg.report_elev,
+    )
+
+
+def get_metrics_config(role: str) -> dict[str, str]:
+    """Get metrics configuration for a role."""
+    cfg = get_config()
+    if role == "repeater":
+        return cfg.repeater_metrics
+    return cfg.companion_metrics
+
+
+def render_monthly_report(
+    role: str,
+    year: int,
+    month: int,
+    prev_period: Optional[tuple[int, int]] = None,
+    next_period: Optional[tuple[int, int]] = None,
+) -> None:
+    """Render monthly report in all formats.
+
+    Args:
+        role: "companion" or "repeater"
+        year: Report year
+        month: Report month (1-12)
+        prev_period: (year, month) of previous report, or None
+        next_period: (year, month) of next report, or None
+    """
+    cfg = get_config()
+    metrics = get_metrics_config(role)
+    node_name = get_node_name(role)
+    location = get_location()
+
+    log.info(f"Aggregating {role} monthly report for {year}-{month:02d}...")
+    agg = aggregate_monthly(role, year, month, metrics)
+
+    if not agg.daily:
+        log.warn(f"No data for {role} {year}-{month:02d}, skipping")
+        return
+
+    # Create output directory
+    out_dir = cfg.out_dir / "reports" / role / str(year) / f"{month:02d}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Build prev/next navigation
+    prev_report = None
+    next_report = None
+    if prev_period:
+        py, pm = prev_period
+        prev_report = {
+            "url": f"/reports/{role}/{py}/{pm:02d}/",
+            "label": f"{calendar.month_abbr[pm]} {py}",
+        }
+    if next_period:
+        ny, nm = next_period
+        next_report = {
+            "url": f"/reports/{role}/{ny}/{nm:02d}/",
+            "label": f"{calendar.month_abbr[nm]} {ny}",
+        }
+
+    # HTML
+    html = render_report_page(agg, node_name, "monthly", prev_report, next_report)
+    safe_write(out_dir / "index.html", html)
+
+    # TXT (WeeWX-style)
+    txt = format_monthly_txt(agg, node_name, location)
+    safe_write(out_dir / "report.txt", txt)
+
+    # JSON
+    json_data = monthly_to_json(agg)
+    safe_write(out_dir / "report.json", json.dumps(json_data, indent=2))
+
+    log.debug(f"Wrote monthly report: {out_dir}")
+
+
+def render_yearly_report(
+    role: str,
+    year: int,
+    prev_year: Optional[int] = None,
+    next_year: Optional[int] = None,
+) -> None:
+    """Render yearly report in all formats.
+
+    Args:
+        role: "companion" or "repeater"
+        year: Report year
+        prev_year: Previous year with data, or None
+        next_year: Next year with data, or None
+    """
+    cfg = get_config()
+    metrics = get_metrics_config(role)
+    node_name = get_node_name(role)
+    location = get_location()
+
+    log.info(f"Aggregating {role} yearly report for {year}...")
+    agg = aggregate_yearly(role, year, metrics)
+
+    if not agg.monthly:
+        log.warn(f"No data for {role} {year}, skipping")
+        return
+
+    # Create output directory
+    out_dir = cfg.out_dir / "reports" / role / str(year)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Build prev/next navigation
+    prev_report = None
+    next_report = None
+    if prev_year:
+        prev_report = {
+            "url": f"/reports/{role}/{prev_year}/",
+            "label": str(prev_year),
+        }
+    if next_year:
+        next_report = {
+            "url": f"/reports/{role}/{next_year}/",
+            "label": str(next_year),
+        }
+
+    # HTML
+    html = render_report_page(agg, node_name, "yearly", prev_report, next_report)
+    safe_write(out_dir / "index.html", html)
+
+    # TXT (WeeWX-style)
+    txt = format_yearly_txt(agg, node_name, location)
+    safe_write(out_dir / "report.txt", txt)
+
+    # JSON
+    json_data = yearly_to_json(agg)
+    safe_write(out_dir / "report.json", json.dumps(json_data, indent=2))
+
+    log.debug(f"Wrote yearly report: {out_dir}")
+
+
+def build_reports_index_data() -> list[dict]:
+    """Build data structure for reports index page.
+
+    Returns:
+        List of section dicts with 'role' and 'years' keys
+    """
+    sections = []
+
+    for role in ["repeater", "companion"]:
+        periods = get_available_periods(role)
+        if not periods:
+            sections.append({"role": role, "years": []})
+            continue
+
+        # Group by year
+        years_data = {}
+        for year, month in periods:
+            if year not in years_data:
+                years_data[year] = []
+            years_data[year].append({
+                "month": month,
+                "name": calendar.month_name[month],
+            })
+
+        # Build years list, sorted descending
+        years = []
+        for year in sorted(years_data.keys(), reverse=True):
+            years.append({
+                "year": year,
+                "months": sorted(years_data[year], key=lambda m: m["month"]),
+            })
+
+        sections.append({"role": role, "years": years})
+
+    return sections
+
+
+def main():
+    """Generate all statistics reports."""
+    cfg = get_config()
+
+    log.info("Generating reports...")
+
+    # Ensure base reports directory exists
+    (cfg.out_dir / "reports").mkdir(parents=True, exist_ok=True)
+
+    total_monthly = 0
+    total_yearly = 0
+
+    for role in ["repeater", "companion"]:
+        periods = get_available_periods(role)
+        if not periods:
+            log.info(f"No snapshot data found for {role}")
+            continue
+
+        log.info(f"Found {len(periods)} months of data for {role}")
+
+        # Sort periods chronologically for prev/next navigation
+        sorted_periods = sorted(periods)
+
+        # Render monthly reports with prev/next links
+        for i, (year, month) in enumerate(sorted_periods):
+            prev_period = sorted_periods[i - 1] if i > 0 else None
+            next_period = sorted_periods[i + 1] if i < len(sorted_periods) - 1 else None
+            render_monthly_report(role, year, month, prev_period, next_period)
+            total_monthly += 1
+
+        # Get unique years
+        years = sorted(set(y for y, m in periods))
+
+        # Render yearly reports with prev/next links
+        for i, year in enumerate(years):
+            prev_year = years[i - 1] if i > 0 else None
+            next_year = years[i + 1] if i < len(years) - 1 else None
+            render_yearly_report(role, year, prev_year, next_year)
+            total_yearly += 1
+
+    # Render reports index
+    log.info("Rendering reports index...")
+    sections = build_reports_index_data()
+    index_html = render_reports_index(sections)
+    safe_write(cfg.out_dir / "reports" / "index.html", index_html)
+
+    log.info(
+        f"Generated {total_monthly} monthly + {total_yearly} yearly reports "
+        f"to {cfg.out_dir / 'reports'}"
+    )
+    log.info("Report generation complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/meshmon/env.py
+++ b/src/meshmon/env.py
@@ -29,6 +29,17 @@ def get_bool(key: str, default: bool = False) -> bool:
     return val in ("1", "true", "yes", "on")
 
 
+def get_float(key: str, default: float) -> float:
+    """Get float env var."""
+    val = os.environ.get(key)
+    if val is None:
+        return default
+    try:
+        return float(val)
+    except ValueError:
+        return default
+
+
 def get_path(key: str, default: str) -> Path:
     """Get path env var, expanding user and making absolute."""
     val = os.environ.get(key, default)
@@ -91,6 +102,22 @@ class Config:
         # Metric mappings
         self.companion_metrics = parse_metrics("COMPANION_METRICS")
         self.repeater_metrics = parse_metrics("REPEATER_METRICS")
+
+        # Report location metadata
+        self.report_location_name = get_str(
+            "REPORT_LOCATION_NAME", "Oosterhout, The Netherlands"
+        )
+        self.report_lat = get_float("REPORT_LAT", 51.6674308)
+        self.report_lon = get_float("REPORT_LON", 4.8596901)
+        self.report_elev = get_float("REPORT_ELEV", 10.0)
+
+        # Node display names for reports
+        self.repeater_display_name = get_str(
+            "REPEATER_DISPLAY_NAME", "jorijn.com Repeater N"
+        )
+        self.companion_display_name = get_str(
+            "COMPANION_DISPLAY_NAME", "Companion Node"
+        )
 
         # Defaults if not specified
         # Based on actual payload structure from device

--- a/src/meshmon/reports.py
+++ b/src/meshmon/reports.py
@@ -1,0 +1,1147 @@
+"""Report generation (WeeWX-style).
+
+This module provides functionality to generate monthly and yearly
+reports from snapshot data. Reports are generated in TXT (WeeWX-style
+ASCII tables), JSON, and HTML formats.
+
+Counter metrics (rx, tx, airtime, etc.) are aggregated using absolute
+counter values from snapshots, summing positive deltas to handle device
+reboots gracefully.
+"""
+
+import calendar
+import json
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any, Optional
+
+from .env import get_config
+from .extract import get_by_path
+from .jsondump import load_snapshot
+from .metrics import is_counter_metric
+from .snapshot import build_companion_merged_view, build_repeater_merged_view
+from . import log
+
+
+# Role-specific merged view builders
+ROLE_BUILDERS = {
+    "companion": build_companion_merged_view,
+    "repeater": build_repeater_merged_view,
+}
+
+
+@dataclass
+class MetricStats:
+    """Statistics for a single metric over a period.
+
+    For gauge metrics: mean, min_value, max_value with timestamps.
+    For counter metrics: total (sum of positive deltas), reboot_count.
+    """
+
+    mean: Optional[float] = None
+    min_value: Optional[float] = None
+    min_time: Optional[datetime] = None
+    max_value: Optional[float] = None
+    max_time: Optional[datetime] = None
+    total: Optional[int] = None  # For counters: sum of positive deltas
+    count: int = 0
+    reboot_count: int = 0  # Number of counter resets detected
+
+    @property
+    def has_data(self) -> bool:
+        """Return True if any meaningful data was collected."""
+        return self.count > 0
+
+
+@dataclass
+class DailyAggregate:
+    """Aggregated metrics for a single day."""
+
+    date: date
+    metrics: dict[str, MetricStats] = field(default_factory=dict)
+    snapshot_count: int = 0
+
+
+@dataclass
+class MonthlyAggregate:
+    """Aggregated metrics for a single month."""
+
+    year: int
+    month: int
+    role: str
+    daily: list[DailyAggregate] = field(default_factory=list)
+    summary: dict[str, MetricStats] = field(default_factory=dict)
+
+
+@dataclass
+class YearlyAggregate:
+    """Aggregated metrics for a full year."""
+
+    year: int
+    role: str
+    monthly: list[MonthlyAggregate] = field(default_factory=list)
+    summary: dict[str, MetricStats] = field(default_factory=dict)
+
+
+def get_merged_view_builder(role: str):
+    """Get the appropriate merged view builder for a role.
+
+    Args:
+        role: "companion" or "repeater"
+
+    Returns:
+        Function that builds merged view from snapshot
+
+    Raises:
+        ValueError: If role is unknown
+    """
+    if role not in ROLE_BUILDERS:
+        raise ValueError(f"Unknown role: {role}")
+    return ROLE_BUILDERS[role]
+
+
+def get_snapshots_for_date(role: str, d: date) -> list[tuple[Path, dict[str, Any]]]:
+    """Load all valid snapshots for a specific date.
+
+    Skips snapshots with skip_reason (circuit breaker, etc.) and
+    snapshots that fail to load.
+
+    Args:
+        role: "companion" or "repeater"
+        d: The date to load snapshots for
+
+    Returns:
+        List of (path, snapshot_data) tuples, sorted by timestamp
+    """
+    cfg = get_config()
+    day_dir = cfg.snapshot_dir / role / f"{d.year}" / f"{d.month:02d}" / f"{d.day:02d}"
+
+    if not day_dir.exists():
+        return []
+
+    snapshots = []
+    skipped_count = 0
+
+    for json_file in sorted(day_dir.glob("*.json")):
+        data = load_snapshot(json_file)
+        if data is None:
+            skipped_count += 1
+            continue
+        if data.get("skip_reason"):
+            # Circuit breaker skip - expected, don't count as error
+            continue
+        if not data.get("ts"):
+            log.debug(f"Snapshot missing timestamp: {json_file}")
+            skipped_count += 1
+            continue
+        snapshots.append((json_file, data))
+
+    if skipped_count > 0:
+        log.debug(f"Skipped {skipped_count} invalid snapshots for {role}/{d}")
+
+    return snapshots
+
+
+def compute_counter_total(
+    values: list[tuple[datetime, int]],
+) -> tuple[Optional[int], int]:
+    """Compute total for a counter metric, handling reboots.
+
+    Sums positive deltas between consecutive readings. Negative deltas
+    (indicating device reboot) are skipped, and the reboot count is tracked.
+
+    Args:
+        values: List of (timestamp, counter_value) tuples, must be sorted by time
+
+    Returns:
+        (total, reboot_count) - total is None if insufficient data (< 2 values)
+    """
+    if len(values) < 2:
+        return (None, 0)
+
+    total = 0
+    reboot_count = 0
+
+    for i in range(1, len(values)):
+        delta = values[i][1] - values[i - 1][1]
+        if delta >= 0:
+            total += delta
+        else:
+            # Negative delta indicates counter reset (reboot)
+            reboot_count += 1
+            # Count from 0 to current value after reboot
+            total += values[i][1]
+
+    return (total, reboot_count)
+
+
+def _compute_gauge_stats(values: list[tuple[datetime, float]]) -> MetricStats:
+    """Compute statistics for a gauge metric.
+
+    Args:
+        values: List of (timestamp, value) tuples
+
+    Returns:
+        MetricStats with mean, min, max populated
+    """
+    if not values:
+        return MetricStats()
+
+    float_values = [v for _, v in values]
+    min_idx = min(range(len(values)), key=lambda i: values[i][1])
+    max_idx = max(range(len(values)), key=lambda i: values[i][1])
+
+    return MetricStats(
+        mean=sum(float_values) / len(float_values),
+        min_value=values[min_idx][1],
+        min_time=values[min_idx][0],
+        max_value=values[max_idx][1],
+        max_time=values[max_idx][0],
+        count=len(values),
+    )
+
+
+def _compute_counter_stats(values: list[tuple[datetime, int]]) -> MetricStats:
+    """Compute statistics for a counter metric.
+
+    Args:
+        values: List of (timestamp, counter_value) tuples
+
+    Returns:
+        MetricStats with total and reboot_count populated
+    """
+    if not values:
+        return MetricStats()
+
+    total, reboot_count = compute_counter_total(values)
+
+    return MetricStats(
+        total=total,
+        count=len(values),
+        reboot_count=reboot_count,
+    )
+
+
+def aggregate_daily(
+    role: str, d: date, metrics_config: dict[str, str]
+) -> DailyAggregate:
+    """Compute daily aggregates from snapshots.
+
+    Args:
+        role: "companion" or "repeater"
+        d: The date to aggregate
+        metrics_config: Mapping of ds_name -> dotted_path
+
+    Returns:
+        DailyAggregate with statistics for all configured metrics
+    """
+    snapshots = get_snapshots_for_date(role, d)
+    agg = DailyAggregate(date=d, snapshot_count=len(snapshots))
+
+    if not snapshots:
+        return agg
+
+    # Get the appropriate builder for this role
+    build_fn = get_merged_view_builder(role)
+    merged_snapshots = [(path, build_fn(data)) for path, data in snapshots]
+
+    # Collect values per metric
+    metric_values: dict[str, list[tuple[datetime, Any]]] = {
+        ds: [] for ds in metrics_config
+    }
+
+    for path, merged in merged_snapshots:
+        ts = datetime.fromtimestamp(merged["ts"])
+        for ds_name, dotted_path in metrics_config.items():
+            val = get_by_path(merged, dotted_path)
+            if val is not None:
+                metric_values[ds_name].append((ts, val))
+
+    # Compute stats per metric
+    for ds_name, values in metric_values.items():
+        if not values:
+            continue
+
+        if is_counter_metric(ds_name):
+            # Convert to int for counter processing
+            int_values = [(ts, int(v)) for ts, v in values]
+            agg.metrics[ds_name] = _compute_counter_stats(int_values)
+        else:
+            # Keep as float for gauge processing
+            float_values = [(ts, float(v)) for ts, v in values]
+            agg.metrics[ds_name] = _compute_gauge_stats(float_values)
+
+    return agg
+
+
+def _aggregate_daily_gauge_to_summary(
+    daily_list: list[DailyAggregate], ds_name: str
+) -> MetricStats:
+    """Aggregate daily gauge stats into a period summary.
+
+    Computes overall mean (weighted by count), min, and max across all days.
+    """
+    total_sum = 0.0
+    total_count = 0
+    overall_min: Optional[tuple[float, datetime]] = None
+    overall_max: Optional[tuple[float, datetime]] = None
+
+    for daily in daily_list:
+        if ds_name not in daily.metrics or not daily.metrics[ds_name].has_data:
+            continue
+
+        stats = daily.metrics[ds_name]
+
+        # Accumulate for weighted mean
+        if stats.mean is not None and stats.count > 0:
+            total_sum += stats.mean * stats.count
+            total_count += stats.count
+
+        # Track overall min
+        if stats.min_value is not None and stats.min_time is not None:
+            if overall_min is None or stats.min_value < overall_min[0]:
+                overall_min = (stats.min_value, stats.min_time)
+
+        # Track overall max
+        if stats.max_value is not None and stats.max_time is not None:
+            if overall_max is None or stats.max_value > overall_max[0]:
+                overall_max = (stats.max_value, stats.max_time)
+
+    if total_count == 0:
+        return MetricStats()
+
+    return MetricStats(
+        mean=total_sum / total_count,
+        min_value=overall_min[0] if overall_min else None,
+        min_time=overall_min[1] if overall_min else None,
+        max_value=overall_max[0] if overall_max else None,
+        max_time=overall_max[1] if overall_max else None,
+        count=total_count,
+    )
+
+
+def _aggregate_daily_counter_to_summary(
+    daily_list: list[DailyAggregate], ds_name: str
+) -> MetricStats:
+    """Aggregate daily counter stats into a period summary.
+
+    Sums totals and reboot counts across all days.
+    """
+    total = 0
+    total_count = 0
+    total_reboots = 0
+
+    for daily in daily_list:
+        if ds_name not in daily.metrics or not daily.metrics[ds_name].has_data:
+            continue
+
+        stats = daily.metrics[ds_name]
+        if stats.total is not None:
+            total += stats.total
+            total_count += stats.count
+            total_reboots += stats.reboot_count
+
+    if total_count == 0:
+        return MetricStats()
+
+    return MetricStats(
+        total=total,
+        count=total_count,
+        reboot_count=total_reboots,
+    )
+
+
+def aggregate_monthly(
+    role: str, year: int, month: int, metrics_config: dict[str, str]
+) -> MonthlyAggregate:
+    """Compute monthly aggregates from daily data.
+
+    Args:
+        role: "companion" or "repeater"
+        year: Year to aggregate
+        month: Month to aggregate (1-12)
+        metrics_config: Mapping of ds_name -> dotted_path
+
+    Returns:
+        MonthlyAggregate with daily data and summary statistics
+    """
+    agg = MonthlyAggregate(year=year, month=month, role=role)
+
+    # Iterate all days in month
+    _, days_in_month = calendar.monthrange(year, month)
+    for day in range(1, days_in_month + 1):
+        d = date(year, month, day)
+        # Don't aggregate future dates
+        if d > date.today():
+            break
+        daily = aggregate_daily(role, d, metrics_config)
+        if daily.snapshot_count > 0:
+            agg.daily.append(daily)
+
+    # Compute monthly summary from daily data
+    for ds_name in metrics_config:
+        if is_counter_metric(ds_name):
+            agg.summary[ds_name] = _aggregate_daily_counter_to_summary(
+                agg.daily, ds_name
+            )
+        else:
+            agg.summary[ds_name] = _aggregate_daily_gauge_to_summary(agg.daily, ds_name)
+
+    return agg
+
+
+def _aggregate_monthly_gauge_to_summary(
+    monthly_list: list[MonthlyAggregate], ds_name: str
+) -> MetricStats:
+    """Aggregate monthly gauge stats into a yearly summary."""
+    total_sum = 0.0
+    total_count = 0
+    overall_min: Optional[tuple[float, datetime]] = None
+    overall_max: Optional[tuple[float, datetime]] = None
+
+    for monthly in monthly_list:
+        if ds_name not in monthly.summary or not monthly.summary[ds_name].has_data:
+            continue
+
+        stats = monthly.summary[ds_name]
+
+        if stats.mean is not None and stats.count > 0:
+            total_sum += stats.mean * stats.count
+            total_count += stats.count
+
+        if stats.min_value is not None and stats.min_time is not None:
+            if overall_min is None or stats.min_value < overall_min[0]:
+                overall_min = (stats.min_value, stats.min_time)
+
+        if stats.max_value is not None and stats.max_time is not None:
+            if overall_max is None or stats.max_value > overall_max[0]:
+                overall_max = (stats.max_value, stats.max_time)
+
+    if total_count == 0:
+        return MetricStats()
+
+    return MetricStats(
+        mean=total_sum / total_count,
+        min_value=overall_min[0] if overall_min else None,
+        min_time=overall_min[1] if overall_min else None,
+        max_value=overall_max[0] if overall_max else None,
+        max_time=overall_max[1] if overall_max else None,
+        count=total_count,
+    )
+
+
+def _aggregate_monthly_counter_to_summary(
+    monthly_list: list[MonthlyAggregate], ds_name: str
+) -> MetricStats:
+    """Aggregate monthly counter stats into a yearly summary."""
+    total = 0
+    total_count = 0
+    total_reboots = 0
+
+    for monthly in monthly_list:
+        if ds_name not in monthly.summary or not monthly.summary[ds_name].has_data:
+            continue
+
+        stats = monthly.summary[ds_name]
+        if stats.total is not None:
+            total += stats.total
+            total_count += stats.count
+            total_reboots += stats.reboot_count
+
+    if total_count == 0:
+        return MetricStats()
+
+    return MetricStats(
+        total=total,
+        count=total_count,
+        reboot_count=total_reboots,
+    )
+
+
+def aggregate_yearly(
+    role: str, year: int, metrics_config: dict[str, str]
+) -> YearlyAggregate:
+    """Compute yearly aggregates from monthly data.
+
+    Args:
+        role: "companion" or "repeater"
+        year: Year to aggregate
+        metrics_config: Mapping of ds_name -> dotted_path
+
+    Returns:
+        YearlyAggregate with monthly data and summary statistics
+    """
+    agg = YearlyAggregate(year=year, role=role)
+
+    # Process month by month to limit memory usage
+    for month in range(1, 13):
+        # Don't aggregate future months
+        if date(year, month, 1) > date.today():
+            break
+        monthly = aggregate_monthly(role, year, month, metrics_config)
+        if monthly.daily:  # Has data
+            agg.monthly.append(monthly)
+
+    # Compute yearly summary from monthly summaries
+    for ds_name in metrics_config:
+        if is_counter_metric(ds_name):
+            agg.summary[ds_name] = _aggregate_monthly_counter_to_summary(
+                agg.monthly, ds_name
+            )
+        else:
+            agg.summary[ds_name] = _aggregate_monthly_gauge_to_summary(
+                agg.monthly, ds_name
+            )
+
+    return agg
+
+
+def get_available_periods(role: str) -> list[tuple[int, int]]:
+    """Find all year/month combinations with snapshot data.
+
+    Args:
+        role: "companion" or "repeater"
+
+    Returns:
+        Sorted list of (year, month) tuples
+    """
+    cfg = get_config()
+    base = cfg.snapshot_dir / role
+
+    if not base.exists():
+        return []
+
+    periods = set()
+    for year_dir in base.glob("*"):
+        if not year_dir.is_dir() or not year_dir.name.isdigit():
+            continue
+        year = int(year_dir.name)
+        for month_dir in year_dir.glob("*"):
+            if not month_dir.is_dir() or not month_dir.name.isdigit():
+                continue
+            month = int(month_dir.name)
+            if 1 <= month <= 12:
+                periods.add((year, month))
+
+    return sorted(periods)
+
+
+def format_lat_lon(lat: float, lon: float) -> tuple[str, str]:
+    """Convert decimal degrees to degrees-minutes format.
+
+    Args:
+        lat: Latitude in decimal degrees (positive = North)
+        lon: Longitude in decimal degrees (positive = East)
+
+    Returns:
+        (lat_str, lon_str) in format "DD-MM.MM N/S", "DDD-MM.MM E/W"
+    """
+    # Latitude
+    lat_dir = "N" if lat >= 0 else "S"
+    lat_abs = abs(lat)
+    lat_deg = int(lat_abs)
+    lat_min = (lat_abs - lat_deg) * 60
+    lat_str = f"{lat_deg:02d}-{lat_min:05.2f} {lat_dir}"
+
+    # Longitude
+    lon_dir = "E" if lon >= 0 else "W"
+    lon_abs = abs(lon)
+    lon_deg = int(lon_abs)
+    lon_min = (lon_abs - lon_deg) * 60
+    lon_str = f"{lon_deg:03d}-{lon_min:05.2f} {lon_dir}"
+
+    return (lat_str, lon_str)
+
+
+@dataclass
+class LocationInfo:
+    """Location metadata for reports."""
+
+    name: str
+    lat: float
+    lon: float
+    elev: float  # meters
+
+    def format_header(self) -> str:
+        """Format location header for text reports."""
+        lat_str, lon_str = format_lat_lon(self.lat, self.lon)
+        return (
+            f"NAME: {self.name}\n"
+            f"ELEV: {self.elev:.0f} meters    LAT: {lat_str}    LONG: {lon_str}"
+        )
+
+
+def _fmt_val(val: Optional[float], width: int = 6, decimals: int = 1) -> str:
+    """Format a value with fixed width, or dashes if None."""
+    if val is None:
+        return "-".center(width)
+    return f"{val:>{width}.{decimals}f}"
+
+
+def _fmt_int(val: Optional[int], width: int = 6) -> str:
+    """Format an integer with fixed width and comma separators, or dashes if None."""
+    if val is None:
+        return "-".center(width)
+    return f"{val:>{width},}"
+
+
+def _fmt_time(dt: Optional[datetime], fmt: str = "%H:%M") -> str:
+    """Format a datetime, or dashes if None."""
+    if dt is None:
+        return "--:--"
+    return dt.strftime(fmt)
+
+
+def _fmt_day(dt: Optional[datetime]) -> str:
+    """Format datetime as day number, or dashes if None."""
+    if dt is None:
+        return "--"
+    return f"{dt.day:02d}"
+
+
+# --- Fixed-width column formatting for yearly reports ---
+
+
+@dataclass
+class Column:
+    """Define a fixed-width column for ASCII table formatting."""
+
+    width: int
+    align: str = "right"  # "left", "right", or "center"
+    decimals: int = 0  # For float formatting
+    comma_sep: bool = False  # Use comma separators for large integers
+
+    def format(self, value: Any) -> str:
+        """Format a value to fit this column width."""
+        if value is None:
+            text = "-"
+        elif isinstance(value, int):
+            if self.comma_sep:
+                text = f"{value:,}"
+            else:
+                text = str(value)
+        elif isinstance(value, float):
+            text = f"{value:.{self.decimals}f}"
+        else:
+            text = str(value)
+
+        if self.align == "left":
+            return text.ljust(self.width)
+        elif self.align == "center":
+            return text.center(self.width)
+        else:  # right
+            return text.rjust(self.width)
+
+
+def _format_row(columns: list[Column], values: list[Any]) -> str:
+    """Format a row of values using column specs."""
+    return "".join(col.format(val) for col, val in zip(columns, values))
+
+
+def _format_separator(columns: list[Column], char: str = "-") -> str:
+    """Generate a separator line matching total width."""
+    return char * sum(col.width for col in columns)
+
+
+def format_monthly_txt_repeater(
+    agg: MonthlyAggregate, node_name: str, location: LocationInfo
+) -> str:
+    """Format monthly aggregate as WeeWX-style text report for repeater.
+
+    Args:
+        agg: Monthly aggregate data
+        node_name: Name of the repeater node
+        location: Location metadata
+
+    Returns:
+        Formatted text report string
+    """
+    month_name = calendar.month_name[agg.month]
+    lines = []
+
+    # Header
+    lines.append(f"                   MONTHLY MESHCORE REPORT for {month_name} {agg.year}")
+    lines.append("")
+    lines.append(f"NODE: {node_name}")
+    lines.append(location.format_header())
+    lines.append("")
+
+    # Table header
+    lines.append("                   BATTERY (V)                    SIGNAL                PACKETS        AIR")
+    lines.append("      MEAN              MIN              MAX      RSSI   SNR    NOISE    RX      TX    SECS")
+    lines.append("DAY   VOLT   %     VOLT  TIME     VOLT  TIME      dBm    dB      dBm")
+    lines.append("-" * 95)
+
+    # Daily rows
+    for daily in agg.daily:
+        day_num = daily.date.day
+        m = daily.metrics
+
+        # Battery
+        bat_v = m.get("bat_v", MetricStats())
+        bat_pct = m.get("bat_pct", MetricStats())
+
+        # Signal
+        rssi = m.get("rssi", MetricStats())
+        snr = m.get("snr", MetricStats())
+        noise = m.get("noise", MetricStats())
+
+        # Packets (counters)
+        rx = m.get("rx", MetricStats())
+        tx = m.get("tx", MetricStats())
+        airtime = m.get("airtime", MetricStats())
+
+        line = (
+            f"{day_num:3d}  "
+            f"{_fmt_val(bat_v.mean, 5, 2)}  {_fmt_val(bat_pct.mean, 3, 0)}  "
+            f"{_fmt_val(bat_v.min_value, 5, 2)}  {_fmt_time(bat_v.min_time)}  "
+            f"{_fmt_val(bat_v.max_value, 5, 2)}  {_fmt_time(bat_v.max_time)}  "
+            f"{_fmt_val(rssi.mean, 5, 0)}  {_fmt_val(snr.mean, 4, 1)}  {_fmt_val(noise.mean, 5, 0)}  "
+            f"{_fmt_int(rx.total, 7)}  {_fmt_int(tx.total, 6)}  {_fmt_int(airtime.total, 5)}"
+        )
+        lines.append(line)
+
+    # Summary row
+    lines.append("-" * 95)
+    s = agg.summary
+    bat_v = s.get("bat_v", MetricStats())
+    bat_pct = s.get("bat_pct", MetricStats())
+    rssi = s.get("rssi", MetricStats())
+    snr = s.get("snr", MetricStats())
+    noise = s.get("noise", MetricStats())
+    rx = s.get("rx", MetricStats())
+    tx = s.get("tx", MetricStats())
+    airtime = s.get("airtime", MetricStats())
+
+    summary_line = (
+        f"AVG  "
+        f"{_fmt_val(bat_v.mean, 5, 2)}  {_fmt_val(bat_pct.mean, 3, 0)}  "
+        f"{_fmt_val(bat_v.min_value, 5, 2)}  {_fmt_day(bat_v.min_time)}     "
+        f"{_fmt_val(bat_v.max_value, 5, 2)}  {_fmt_day(bat_v.max_time)}     "
+        f"{_fmt_val(rssi.mean, 5, 0)}  {_fmt_val(snr.mean, 4, 1)}  {_fmt_val(noise.mean, 5, 0)}  "
+        f"{_fmt_int(rx.total, 7)}  {_fmt_int(tx.total, 6)}  {_fmt_int(airtime.total, 5)}"
+    )
+    lines.append(summary_line)
+
+    return "\n".join(lines)
+
+
+def format_monthly_txt_companion(
+    agg: MonthlyAggregate, node_name: str, location: LocationInfo
+) -> str:
+    """Format monthly aggregate as WeeWX-style text report for companion.
+
+    Args:
+        agg: Monthly aggregate data
+        node_name: Name of the companion node
+        location: Location metadata
+
+    Returns:
+        Formatted text report string
+    """
+    month_name = calendar.month_name[agg.month]
+    lines = []
+
+    # Header
+    lines.append(f"                   MONTHLY MESHCORE REPORT for {month_name} {agg.year}")
+    lines.append("")
+    lines.append(f"NODE: {node_name}")
+    lines.append(location.format_header())
+    lines.append("")
+
+    # Table header - companion has fewer metrics
+    lines.append("                   BATTERY (V)                            PACKETS")
+    lines.append("      MEAN              MIN              MAX      CONTACTS    RX      TX")
+    lines.append("DAY   VOLT   %     VOLT  TIME     VOLT  TIME")
+    lines.append("-" * 75)
+
+    # Daily rows
+    for daily in agg.daily:
+        day_num = daily.date.day
+        m = daily.metrics
+
+        bat_v = m.get("bat_v", MetricStats())
+        bat_pct = m.get("bat_pct", MetricStats())
+        contacts = m.get("contacts", MetricStats())
+        rx = m.get("rx", MetricStats())
+        tx = m.get("tx", MetricStats())
+
+        line = (
+            f"{day_num:3d}  "
+            f"{_fmt_val(bat_v.mean, 5, 2)}  {_fmt_val(bat_pct.mean, 3, 0)}  "
+            f"{_fmt_val(bat_v.min_value, 5, 2)}  {_fmt_time(bat_v.min_time)}  "
+            f"{_fmt_val(bat_v.max_value, 5, 2)}  {_fmt_time(bat_v.max_time)}  "
+            f"{_fmt_val(contacts.mean, 6, 0)}  "
+            f"{_fmt_int(rx.total, 7)}  {_fmt_int(tx.total, 6)}"
+        )
+        lines.append(line)
+
+    # Summary row
+    lines.append("-" * 75)
+    s = agg.summary
+    bat_v = s.get("bat_v", MetricStats())
+    bat_pct = s.get("bat_pct", MetricStats())
+    contacts = s.get("contacts", MetricStats())
+    rx = s.get("rx", MetricStats())
+    tx = s.get("tx", MetricStats())
+
+    summary_line = (
+        f"AVG  "
+        f"{_fmt_val(bat_v.mean, 5, 2)}  {_fmt_val(bat_pct.mean, 3, 0)}  "
+        f"{_fmt_val(bat_v.min_value, 5, 2)}  {_fmt_day(bat_v.min_time)}     "
+        f"{_fmt_val(bat_v.max_value, 5, 2)}  {_fmt_day(bat_v.max_time)}     "
+        f"{_fmt_val(contacts.mean, 6, 0)}  "
+        f"{_fmt_int(rx.total, 7)}  {_fmt_int(tx.total, 6)}"
+    )
+    lines.append(summary_line)
+
+    return "\n".join(lines)
+
+
+def format_monthly_txt(
+    agg: MonthlyAggregate, node_name: str, location: LocationInfo
+) -> str:
+    """Format monthly aggregate as WeeWX-style text report.
+
+    Dispatches to role-specific formatter.
+
+    Args:
+        agg: Monthly aggregate data
+        node_name: Name of the node
+        location: Location metadata
+
+    Returns:
+        Formatted text report string
+    """
+    if agg.role == "repeater":
+        return format_monthly_txt_repeater(agg, node_name, location)
+    else:
+        return format_monthly_txt_companion(agg, node_name, location)
+
+
+def format_yearly_txt_repeater(
+    agg: YearlyAggregate, node_name: str, location: LocationInfo
+) -> str:
+    """Format yearly aggregate as WeeWX-style text report for repeater.
+
+    Args:
+        agg: Yearly aggregate data
+        node_name: Name of the repeater node
+        location: Location metadata
+
+    Returns:
+        Formatted text report string
+    """
+    # Define column layout - all rows will use these exact widths
+    # YR MO | VOLT % | HIGH DAY | LOW DAY | RSSI SNR | RX TX
+    cols = [
+        Column(4),                        # YR
+        Column(4),                        # MO
+        Column(6, decimals=2),            # VOLT (mean)
+        Column(4),                        # % (bat_pct)
+        Column(6, decimals=2),            # HIGH (max volt)
+        Column(4),                        # DAY (max day)
+        Column(6, decimals=2),            # LOW (min volt)
+        Column(4),                        # DAY (min day)
+        Column(6),                        # RSSI
+        Column(6, decimals=1),            # SNR
+        Column(11, comma_sep=True),       # RX
+        Column(9, comma_sep=True),        # TX
+    ]
+
+    lines = []
+
+    # Header
+    title = f"YEARLY MESHCORE REPORT for {agg.year}"
+    lines.append(title.center(sum(c.width for c in cols)))
+    lines.append("")
+    lines.append(f"NODE: {node_name}")
+    lines.append(location.format_header())
+    lines.append("")
+
+    # Table headers - use same column widths
+    lines.append(_format_row(cols, [
+        "", "", "BATTERY", "", "", "", "", "", "SIGNAL", "", "PACKETS", ""
+    ]))
+    lines.append(_format_row(cols, [
+        "YR", "MO", "VOLT", "%", "HIGH", "DAY", "LOW", "DAY", "RSSI", "SNR", "RX", "TX"
+    ]))
+    lines.append(_format_separator(cols))
+
+    # Monthly rows
+    for monthly in agg.monthly:
+        s = monthly.summary
+        bat_v = s.get("bat_v", MetricStats())
+        bat_pct = s.get("bat_pct", MetricStats())
+        rssi = s.get("rssi", MetricStats())
+        snr = s.get("snr", MetricStats())
+        rx = s.get("rx", MetricStats())
+        tx = s.get("tx", MetricStats())
+
+        # Format day as 2-digit number
+        max_day = f"{bat_v.max_time.day:02d}" if bat_v.max_time else "--"
+        min_day = f"{bat_v.min_time.day:02d}" if bat_v.min_time else "--"
+
+        lines.append(_format_row(cols, [
+            agg.year,
+            f"{monthly.month:02d}",
+            bat_v.mean,
+            int(bat_pct.mean) if bat_pct.mean is not None else None,
+            bat_v.max_value,
+            max_day,
+            bat_v.min_value,
+            min_day,
+            int(rssi.mean) if rssi.mean is not None else None,
+            snr.mean,
+            rx.total,
+            tx.total,
+        ]))
+
+    # Summary row
+    lines.append(_format_separator(cols))
+    s = agg.summary
+    bat_v = s.get("bat_v", MetricStats())
+    bat_pct = s.get("bat_pct", MetricStats())
+    rssi = s.get("rssi", MetricStats())
+    snr = s.get("snr", MetricStats())
+    rx = s.get("rx", MetricStats())
+    tx = s.get("tx", MetricStats())
+
+    max_month = calendar.month_abbr[bat_v.max_time.month] if bat_v.max_time else "---"
+    min_month = calendar.month_abbr[bat_v.min_time.month] if bat_v.min_time else "---"
+
+    lines.append(_format_row(cols, [
+        "",
+        "AVG",
+        bat_v.mean,
+        int(bat_pct.mean) if bat_pct.mean is not None else None,
+        bat_v.max_value,
+        max_month,
+        bat_v.min_value,
+        min_month,
+        int(rssi.mean) if rssi.mean is not None else None,
+        snr.mean,
+        rx.total,
+        tx.total,
+    ]))
+
+    return "\n".join(lines)
+
+
+def format_yearly_txt_companion(
+    agg: YearlyAggregate, node_name: str, location: LocationInfo
+) -> str:
+    """Format yearly aggregate as WeeWX-style text report for companion.
+
+    Args:
+        agg: Yearly aggregate data
+        node_name: Name of the companion node
+        location: Location metadata
+
+    Returns:
+        Formatted text report string
+    """
+    # Define column layout - all rows will use these exact widths
+    # YR MO | VOLT % | HIGH DAY | LOW DAY | CNTS | RX TX
+    cols = [
+        Column(4),                        # YR
+        Column(4),                        # MO
+        Column(6, decimals=2),            # VOLT (mean)
+        Column(4),                        # % (bat_pct)
+        Column(6, decimals=2),            # HIGH (max volt)
+        Column(4),                        # DAY (max day)
+        Column(6, decimals=2),            # LOW (min volt)
+        Column(4),                        # DAY (min day)
+        Column(6),                        # CNTS (contacts)
+        Column(11, comma_sep=True),       # RX
+        Column(9, comma_sep=True),        # TX
+    ]
+
+    lines = []
+
+    # Header
+    title = f"YEARLY MESHCORE REPORT for {agg.year}"
+    lines.append(title.center(sum(c.width for c in cols)))
+    lines.append("")
+    lines.append(f"NODE: {node_name}")
+    lines.append(location.format_header())
+    lines.append("")
+
+    # Table headers - use same column widths
+    lines.append(_format_row(cols, [
+        "", "", "BATTERY", "", "", "", "", "", "", "PACKETS", ""
+    ]))
+    lines.append(_format_row(cols, [
+        "YR", "MO", "VOLT", "%", "HIGH", "DAY", "LOW", "DAY", "CNTS", "RX", "TX"
+    ]))
+    lines.append(_format_separator(cols))
+
+    # Monthly rows
+    for monthly in agg.monthly:
+        s = monthly.summary
+        bat_v = s.get("bat_v", MetricStats())
+        bat_pct = s.get("bat_pct", MetricStats())
+        contacts = s.get("contacts", MetricStats())
+        rx = s.get("rx", MetricStats())
+        tx = s.get("tx", MetricStats())
+
+        max_day = f"{bat_v.max_time.day:02d}" if bat_v.max_time else "--"
+        min_day = f"{bat_v.min_time.day:02d}" if bat_v.min_time else "--"
+
+        lines.append(_format_row(cols, [
+            agg.year,
+            f"{monthly.month:02d}",
+            bat_v.mean,
+            int(bat_pct.mean) if bat_pct.mean is not None else None,
+            bat_v.max_value,
+            max_day,
+            bat_v.min_value,
+            min_day,
+            int(contacts.mean) if contacts.mean is not None else None,
+            rx.total,
+            tx.total,
+        ]))
+
+    # Summary row
+    lines.append(_format_separator(cols))
+    s = agg.summary
+    bat_v = s.get("bat_v", MetricStats())
+    bat_pct = s.get("bat_pct", MetricStats())
+    contacts = s.get("contacts", MetricStats())
+    rx = s.get("rx", MetricStats())
+    tx = s.get("tx", MetricStats())
+
+    max_month = calendar.month_abbr[bat_v.max_time.month] if bat_v.max_time else "---"
+    min_month = calendar.month_abbr[bat_v.min_time.month] if bat_v.min_time else "---"
+
+    lines.append(_format_row(cols, [
+        "",
+        "AVG",
+        bat_v.mean,
+        int(bat_pct.mean) if bat_pct.mean is not None else None,
+        bat_v.max_value,
+        max_month,
+        bat_v.min_value,
+        min_month,
+        int(contacts.mean) if contacts.mean is not None else None,
+        rx.total,
+        tx.total,
+    ]))
+
+    return "\n".join(lines)
+
+
+def format_yearly_txt(
+    agg: YearlyAggregate, node_name: str, location: LocationInfo
+) -> str:
+    """Format yearly aggregate as WeeWX-style text report.
+
+    Dispatches to role-specific formatter.
+
+    Args:
+        agg: Yearly aggregate data
+        node_name: Name of the node
+        location: Location metadata
+
+    Returns:
+        Formatted text report string
+    """
+    if agg.role == "repeater":
+        return format_yearly_txt_repeater(agg, node_name, location)
+    else:
+        return format_yearly_txt_companion(agg, node_name, location)
+
+
+def _metric_stats_to_dict(stats: MetricStats) -> dict[str, Any]:
+    """Convert MetricStats to JSON-serializable dict."""
+    result: dict[str, Any] = {"count": stats.count}
+
+    if stats.mean is not None:
+        result["mean"] = round(stats.mean, 4)
+    if stats.min_value is not None:
+        result["min"] = round(stats.min_value, 4)
+    if stats.min_time is not None:
+        result["min_time"] = stats.min_time.isoformat()
+    if stats.max_value is not None:
+        result["max"] = round(stats.max_value, 4)
+    if stats.max_time is not None:
+        result["max_time"] = stats.max_time.isoformat()
+    if stats.total is not None:
+        result["total"] = stats.total
+    if stats.reboot_count > 0:
+        result["reboot_count"] = stats.reboot_count
+
+    return result
+
+
+def _daily_to_dict(daily: DailyAggregate) -> dict[str, Any]:
+    """Convert DailyAggregate to JSON-serializable dict."""
+    return {
+        "date": daily.date.isoformat(),
+        "snapshot_count": daily.snapshot_count,
+        "metrics": {
+            ds: _metric_stats_to_dict(stats)
+            for ds, stats in daily.metrics.items()
+            if stats.has_data
+        },
+    }
+
+
+def monthly_to_json(agg: MonthlyAggregate) -> dict[str, Any]:
+    """Convert MonthlyAggregate to JSON-serializable dict.
+
+    Args:
+        agg: Monthly aggregate data
+
+    Returns:
+        JSON-serializable dict
+    """
+    return {
+        "report_type": "monthly",
+        "year": agg.year,
+        "month": agg.month,
+        "role": agg.role,
+        "days_with_data": len(agg.daily),
+        "summary": {
+            ds: _metric_stats_to_dict(stats)
+            for ds, stats in agg.summary.items()
+            if stats.has_data
+        },
+        "daily": [_daily_to_dict(d) for d in agg.daily],
+    }
+
+
+def yearly_to_json(agg: YearlyAggregate) -> dict[str, Any]:
+    """Convert YearlyAggregate to JSON-serializable dict.
+
+    Args:
+        agg: Yearly aggregate data
+
+    Returns:
+        JSON-serializable dict
+    """
+    return {
+        "report_type": "yearly",
+        "year": agg.year,
+        "role": agg.role,
+        "months_with_data": len(agg.monthly),
+        "summary": {
+            ds: _metric_stats_to_dict(stats)
+            for ds, stats in agg.summary.items()
+            if stats.has_data
+        },
+        "monthly": [
+            {
+                "year": m.year,
+                "month": m.month,
+                "days_with_data": len(m.daily),
+                "summary": {
+                    ds: _metric_stats_to_dict(stats)
+                    for ds, stats in m.summary.items()
+                    if stats.has_data
+                },
+            }
+            for m in agg.monthly
+        ],
+    }

--- a/src/meshmon/templates/base.html
+++ b/src/meshmon/templates/base.html
@@ -565,6 +565,304 @@
             }
         }
 
+        /* Visually hidden - for screen readers only */
+        .visually-hidden {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
+        }
+
+        /* Reports index page */
+        .reports-intro-card {
+            margin-bottom: var(--space-6);
+        }
+        .reports-intro-card .card-body {
+            padding: var(--space-4) var(--space-6);
+        }
+        .reports-intro-card .card-body p {
+            color: var(--text-muted);
+            margin: 0;
+            font-size: var(--font-size-sm);
+        }
+        .report-year-section {
+            margin-bottom: var(--space-4);
+        }
+        .report-year-section:last-child {
+            margin-bottom: 0;
+        }
+        .report-year-heading {
+            font-size: var(--font-size-xs);
+            font-weight: 600;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            margin: 0 0 var(--space-2) 0;
+        }
+        .report-list {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+        }
+        .report-item {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: var(--space-2) 0;
+            border-bottom: 1px solid var(--border);
+            font-size: var(--font-size-sm);
+        }
+        .report-item:last-child {
+            border-bottom: none;
+        }
+        .report-name {
+            color: var(--text);
+        }
+        .report-links {
+            display: flex;
+            align-items: baseline;
+            gap: var(--space-3);
+        }
+        .report-link-view {
+            color: var(--primary);
+            text-decoration: none;
+            font-weight: 500;
+            min-width: 2.5rem;
+            text-align: right;
+        }
+        .report-link-view:hover {
+            text-decoration: underline;
+        }
+        .report-link-dl {
+            color: var(--text-muted);
+            text-decoration: none;
+            font-size: var(--font-size-xs);
+            min-width: 2rem;
+            text-align: right;
+        }
+        .report-link-dl:hover {
+            color: var(--text);
+        }
+        .report-link-dl:focus-visible {
+            color: var(--primary);
+            outline: 2px solid var(--primary);
+            outline-offset: 2px;
+        }
+        .report-year-divider {
+            border: none;
+            border-top: 1px solid var(--border);
+            margin: var(--space-4) 0;
+        }
+        .report-empty {
+            color: var(--text-muted);
+            font-size: var(--font-size-sm);
+            margin: 0;
+        }
+
+        /* Report detail page */
+        .report-page { margin-bottom: var(--space-6); }
+        .report-header { margin-bottom: var(--space-4); }
+
+        /* Report header bar - title and downloads side by side */
+        .report-header-bar {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            flex-wrap: wrap;
+            gap: var(--space-3);
+        }
+
+        /* Download buttons group */
+        .report-downloads {
+            display: flex;
+            gap: var(--space-2);
+        }
+
+        /* Button styles (reusable) */
+        .btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: var(--space-2);
+            padding: var(--space-2) var(--space-4);
+            font-size: var(--font-size-sm);
+            font-weight: 500;
+            text-decoration: none;
+            border-radius: var(--radius);
+            border: 1px solid transparent;
+            cursor: pointer;
+            transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+            min-height: 36px;
+        }
+        .btn:focus-visible {
+            outline: 2px solid var(--primary);
+            outline-offset: 2px;
+        }
+        .btn--sm {
+            padding: var(--space-1) var(--space-3);
+            font-size: var(--font-size-xs);
+            min-height: 32px;
+        }
+        .btn--secondary {
+            background: var(--bg-elevated);
+            border-color: var(--border);
+            color: var(--text-muted);
+        }
+        .btn--secondary:hover {
+            background: var(--bg-sunken);
+            border-color: var(--border-strong);
+            color: var(--text);
+        }
+        .btn-icon {
+            width: 14px;
+            height: 14px;
+            flex-shrink: 0;
+        }
+
+        /* Inline metadata - horizontal flow with dividers */
+        .report-meta-inline {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: baseline;
+            gap: var(--space-2) var(--space-4);
+            margin: 0;
+        }
+        .meta-group {
+            display: flex;
+            align-items: baseline;
+            gap: var(--space-2);
+        }
+        .meta-group dt {
+            font-size: var(--font-size-xs);
+            color: var(--text-subtle);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+        .meta-group dd {
+            font-size: var(--font-size-sm);
+            color: var(--text);
+            font-weight: 500;
+            margin: 0;
+        }
+        .meta-divider {
+            width: 1px;
+            height: 1em;
+            background: var(--border);
+            align-self: center;
+        }
+        .report-content { margin-bottom: var(--space-4); }
+        .table-scroll-wrapper {
+            overflow-x: auto;
+            -webkit-overflow-scrolling: touch;
+        }
+        .report-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: var(--font-size-sm);
+            font-variant-numeric: tabular-nums;
+        }
+        .report-table th, .report-table td {
+            padding: var(--space-2) var(--space-3);
+            text-align: right;
+            white-space: nowrap;
+            border-bottom: 1px solid var(--border);
+        }
+        .report-table th {
+            background: var(--bg-sunken);
+            font-weight: 600;
+            color: var(--text);
+            position: sticky;
+            top: 0;
+        }
+        .report-table th:first-child,
+        .report-table td:first-child {
+            text-align: left;
+        }
+        .report-table tbody tr:hover {
+            background: var(--bg-sunken);
+        }
+        .report-table .summary-row {
+            font-weight: 600;
+            background: var(--bg-sunken);
+        }
+        .report-table .summary-row td {
+            border-top: 2px solid var(--border-strong);
+        }
+        .report-pagination {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: var(--space-4);
+            padding: var(--space-4) var(--space-5);
+            background: var(--bg-elevated);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+        }
+        .report-pagination .pagination-link {
+            font-size: var(--font-size-sm);
+            color: var(--text-muted);
+            text-decoration: none;
+            padding: var(--space-2) var(--space-3);
+            border-radius: var(--radius);
+            transition: color 0.15s, background-color 0.15s;
+            min-width: 100px;
+        }
+        .report-pagination .pagination-link:hover {
+            color: var(--text);
+            background: var(--bg-sunken);
+        }
+        .report-pagination .pagination-link--disabled {
+            color: var(--text-subtle);
+            pointer-events: none;
+        }
+        .report-pagination .pagination-link--prev {
+            text-align: left;
+        }
+        .report-pagination .pagination-link--next {
+            text-align: right;
+        }
+        .report-pagination .pagination-center {
+            font-size: var(--font-size-sm);
+            font-weight: 500;
+            color: var(--primary);
+            text-decoration: none;
+            padding: var(--space-2) var(--space-4);
+            background: var(--primary-light);
+            border-radius: var(--radius);
+            transition: background-color 0.15s;
+        }
+        .report-pagination .pagination-center:hover {
+            background: var(--primary);
+            color: white;
+        }
+        @media (max-width: 600px) {
+            .report-header-bar {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+            .report-downloads {
+                width: 100%;
+            }
+            .report-downloads .btn {
+                flex: 1;
+            }
+            .report-meta-inline {
+                flex-direction: column;
+                gap: var(--space-2);
+            }
+            .meta-divider {
+                display: none;
+            }
+            .report-table { font-size: var(--font-size-xs); }
+            .report-table th, .report-table td { padding: var(--space-1) var(--space-2); }
+            .report-pagination { flex-direction: column; }
+        }
+
     </style>
     <script>
     // Apply saved theme immediately to prevent flash
@@ -582,14 +880,15 @@
             <div class="header-node">
                 <h1>{{ node_name }}</h1>
                 {% if pubkey_pre %}<code class="pubkey">{{ pubkey_pre }}</code>{% endif %}
-                <span class="status-indicator status-{{ status_class }}" title="{{ status_text }}"></span>
+                <span class="status-indicator status-{{ status_class }}" title="{{ status_text }}" aria-hidden="true"></span>
+                <span class="visually-hidden">Status: {{ status_text }}</span>
             </div>
             <div class="header-updated">
                 <div class="updated-text">
                     <span class="label">Last updated</span>
                     {% if last_updated %}{{ last_updated }}{% else %}N/A{% endif %}
                 </div>
-                <button class="theme-toggle" aria-label="Toggle dark mode" title="Toggle theme">
+                <button type="button" class="theme-toggle" aria-label="Toggle dark mode" title="Toggle theme">
                     <svg class="icon-sun" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <circle cx="12" cy="12" r="5"/>
                         <line x1="12" y1="1" x2="12" y2="3"/>
@@ -610,8 +909,8 @@
 
         <nav class="main-nav" aria-label="Main navigation">
             <div class="nav-group" aria-label="Node selection">
-                <a href="/day.html" class="nav-link{% if role == 'repeater' %} active{% endif %}"{% if role == 'repeater' %} aria-current="page"{% endif %}>Repeater</a>
-                <a href="/companion/day.html" class="nav-link{% if role == 'companion' %} active{% endif %}"{% if role == 'companion' %} aria-current="page"{% endif %}>Companion</a>
+                <a href="/day.html" class="nav-link{% if role == 'repeater' and page_type != 'reports' %} active{% endif %}"{% if role == 'repeater' and page_type != 'reports' %} aria-current="page"{% endif %}>Repeater</a>
+                <a href="/companion/day.html" class="nav-link{% if role == 'companion' and page_type != 'reports' %} active{% endif %}"{% if role == 'companion' and page_type != 'reports' %} aria-current="page"{% endif %}>Companion</a>
             </div>
             <span class="nav-separator" aria-hidden="true">|</span>
             <div class="nav-group" aria-label="Time period">
@@ -619,6 +918,10 @@
                 <a href="{{ base_path }}/week.html" class="nav-link{% if period == 'week' %} active{% endif %}">Week</a>
                 <a href="{{ base_path }}/month.html" class="nav-link{% if period == 'month' %} active{% endif %}">Month</a>
                 <a href="{{ base_path }}/year.html" class="nav-link{% if period == 'year' %} active{% endif %}">Year</a>
+            </div>
+            <span class="nav-separator" aria-hidden="true">|</span>
+            <div class="nav-group" aria-label="Reports">
+                <a href="/reports/" class="nav-link{% if page_type == 'reports' %} active{% endif %}"{% if page_type == 'reports' %} aria-current="page"{% endif %}>Reports</a>
             </div>
         </nav>
 

--- a/src/meshmon/templates/report.html
+++ b/src/meshmon/templates/report.html
@@ -1,0 +1,95 @@
+{% extends "base.html" %}
+{% block content %}
+<article class="report-page">
+    <header class="report-header card">
+        <div class="card-header report-header-bar">
+            <h2 class="card-title">{{ report_title }}</h2>
+            <div class="report-downloads" role="group" aria-label="Download report">
+                <a href="report.txt" class="btn btn--secondary btn--sm" download="{{ download_prefix }}.txt">
+                    <svg class="btn-icon" aria-hidden="true" viewBox="0 0 20 20" fill="currentColor">
+                        <path fill-rule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd"/>
+                    </svg>
+                    <span>TXT</span>
+                </a>
+                <a href="report.json" class="btn btn--secondary btn--sm" download="{{ download_prefix }}.json">
+                    <svg class="btn-icon" aria-hidden="true" viewBox="0 0 20 20" fill="currentColor">
+                        <path fill-rule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clip-rule="evenodd"/>
+                    </svg>
+                    <span>JSON</span>
+                </a>
+            </div>
+        </div>
+        <div class="card-body">
+            <dl class="report-meta-inline">
+                <div class="meta-group">
+                    <dt>Node</dt>
+                    <dd>{{ node_name }}</dd>
+                </div>
+                <span class="meta-divider" aria-hidden="true"></span>
+                <div class="meta-group">
+                    <dt>Location</dt>
+                    <dd>{{ location_name }}</dd>
+                </div>
+                <span class="meta-divider" aria-hidden="true"></span>
+                <div class="meta-group">
+                    <dt>Coordinates</dt>
+                    <dd>{{ lat_str }}, {{ lon_str }} ({{ elev }}m)</dd>
+                </div>
+                <span class="meta-divider" aria-hidden="true"></span>
+                <div class="meta-group">
+                    <dt>Generated</dt>
+                    <dd><time datetime="{{ generated_iso }}">{{ generated_at }}</time></dd>
+                </div>
+            </dl>
+        </div>
+    </header>
+
+    <section class="report-content card" aria-labelledby="report-data-heading">
+        <div class="card-header">
+            <h2 id="report-data-heading" class="card-title">Report Data</h2>
+        </div>
+        <div class="card-body">
+            <div class="table-scroll-wrapper">
+                <table class="report-table">
+                    <thead>
+                        <tr>
+                            {% for header in table_headers %}
+                            <th scope="col"{% if header.tooltip %} title="{{ header.tooltip }}"{% endif %}>{{ header.label }}</th>
+                            {% endfor %}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for row in table_rows %}
+                        <tr{% if row.is_summary %} class="summary-row"{% endif %}>
+                            {% for cell in row.cells %}
+                            <td{% if cell.class %} class="{{ cell.class }}"{% endif %}>{{ cell.value }}</td>
+                            {% endfor %}
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </section>
+
+    <nav class="report-pagination" aria-label="Report navigation">
+        {% if prev_report %}
+        <a href="{{ prev_report.url }}" class="pagination-link pagination-link--prev" rel="prev">
+            &larr; {{ prev_report.label }}
+        </a>
+        {% else %}
+        <span class="pagination-link pagination-link--prev pagination-link--disabled">&larr; Previous</span>
+        {% endif %}
+
+        <a href="/reports/" class="pagination-center" rel="up">All Reports</a>
+
+        {% if next_report %}
+        <a href="{{ next_report.url }}" class="pagination-link pagination-link--next" rel="next">
+            {{ next_report.label }} &rarr;
+        </a>
+        {% else %}
+        <span class="pagination-link pagination-link--next pagination-link--disabled">Next &rarr;</span>
+        {% endif %}
+    </nav>
+</article>
+{% endblock %}

--- a/src/meshmon/templates/report_index.html
+++ b/src/meshmon/templates/report_index.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="reports-intro-card card">
+    <div class="card-body">
+        <p>Monthly and yearly statistics reports for the mesh network. Each report is available as a web page, plain text, or JSON.</p>
+    </div>
+</div>
+
+<div class="dashboard-grid">
+{% for section in report_sections %}
+<section class="card" aria-labelledby="reports-{{ section.role }}-heading">
+    <div class="card-header">
+        <h2 id="reports-{{ section.role }}-heading" class="card-title">{{ section.role | capitalize }}</h2>
+    </div>
+    <div class="card-body">
+        {% if section.years %}
+        {% for year_data in section.years %}
+        <div class="report-year-section">
+            <h3 class="report-year-heading">{{ year_data.year }}</h3>
+            <ul class="report-list">
+                <li class="report-item">
+                    <span class="report-name">Annual Summary</span>
+                    <span class="report-links">
+                        <a href="/reports/{{ section.role }}/{{ year_data.year }}/" class="report-link-view">View</a>
+                        <a href="/reports/{{ section.role }}/{{ year_data.year }}/report.txt" class="report-link-dl">TXT</a>
+                        <a href="/reports/{{ section.role }}/{{ year_data.year }}/report.json" class="report-link-dl">JSON</a>
+                    </span>
+                </li>
+                {% for month in year_data.months | reverse %}
+                <li class="report-item">
+                    <span class="report-name">{{ month.name }}</span>
+                    <span class="report-links">
+                        <a href="/reports/{{ section.role }}/{{ year_data.year }}/{{ '%02d' | format(month.month) }}/" class="report-link-view">View</a>
+                        <a href="/reports/{{ section.role }}/{{ year_data.year }}/{{ '%02d' | format(month.month) }}/report.txt" class="report-link-dl">TXT</a>
+                        <a href="/reports/{{ section.role }}/{{ year_data.year }}/{{ '%02d' | format(month.month) }}/report.json" class="report-link-dl">JSON</a>
+                    </span>
+                </li>
+                {% endfor %}
+            </ul>
+        </div>
+        {% if not loop.last %}
+        <hr class="report-year-divider">
+        {% endif %}
+        {% endfor %}
+        {% else %}
+        <p class="report-empty">No reports available yet.</p>
+        {% endif %}
+    </div>
+</section>
+{% endfor %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Adds Phase 4 report generation with monthly/yearly aggregation from snapshot data
- Generates reports in 3 formats: HTML (responsive web pages), TXT (WeeWX-style ASCII tables), and JSON
- Creates reports index page with navigation and styled report detail pages with prev/next links
- Adds configurable node display names (`REPEATER_DISPLAY_NAME`, `COMPANION_DISPLAY_NAME`) and location metadata
- Includes WCAG accessibility improvements: `scope` attributes on table headers, `.visually-hidden` utility class, focus-visible states, proper button types

## Test plan
- [ ] Run `python scripts/phase4_render_reports.py` and verify reports generate without errors
- [ ] Check `/reports/` index page renders with correct structure
- [ ] Verify monthly report pages show daily data with proper column alignment
- [ ] Verify yearly report pages show monthly summaries
- [ ] Download TXT and JSON files and verify formatting
- [ ] Test prev/next navigation between reports
- [ ] Test responsive layout on mobile viewports
- [ ] Verify dark mode works correctly on report pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)