### PR TITLE
refactor: migrate to EAV schema for flexible metric storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,10 +20,7 @@ build/
 data/snapshots/companion/**/*.json
 data/snapshots/repeater/**/*.json
 data/rrd/*.rrd
-data/state/*.json
-data/state/*.db
-data/state/*.db-shm
-data/state/*.db-wal
+data/state/*
 
 # Generated output (except .htaccess)
 out/*

--- a/docs/firmware-responses.md
+++ b/docs/firmware-responses.md
@@ -1,0 +1,120 @@
+# MeshCore Firmware Response Reference
+
+This document captures the actual response structures from MeshCore firmware commands.
+Use this as a reference when updating collectors or adding new metrics.
+
+> **Last verified**: 2025-12-29
+
+---
+
+## Companion Node
+
+The companion node is queried via USB serial using multiple commands.
+
+### `get_stats_core()`
+
+Core system statistics.
+
+```python
+{
+    'battery_mv': 3895,      # Battery voltage in millivolts
+    'uptime_secs': 126,      # Uptime in seconds
+    'errors': 0,             # Error count
+    'queue_len': 0           # Message queue length
+}
+```
+
+### `get_stats_packets()`
+
+Packet counters (cumulative since boot).
+
+```python
+{
+    'recv': 20,              # Total packets received
+    'sent': 0,               # Total packets sent
+    'flood_tx': 0,           # Flood packets transmitted
+    'direct_tx': 0,          # Direct packets transmitted
+    'flood_rx': 20,          # Flood packets received
+    'direct_rx': 0           # Direct packets received
+}
+```
+
+### `get_stats_radio()`
+
+Radio/RF statistics.
+
+```python
+{
+    'noise_floor': -113,     # Noise floor in dBm
+    'last_rssi': -123,       # RSSI of last received packet (dBm)
+    'last_snr': -8.5,        # SNR of last received packet (dB)
+    'tx_air_secs': 0,        # Cumulative TX airtime in seconds
+    'rx_air_secs': 11        # Cumulative RX airtime in seconds
+}
+```
+
+### `get_bat()`
+
+Battery/storage info (note: not the main battery source for metrics).
+
+```python
+{
+    'level': 4436,           # Battery level (unclear unit)
+    'used_kb': 256,          # Used storage in KB
+    'total_kb': 1404         # Total storage in KB
+}
+```
+
+### `get_contacts()`
+
+Returns a dict keyed by public key. Count via `len(payload)`.
+
+---
+
+## Repeater Node
+
+The repeater is queried over LoRa using the binary protocol command `req_status_sync()`.
+
+### `req_status_sync(contact)`
+
+Returns a single dict with all status fields.
+
+```python
+{
+    'bat': 4047,             # Battery voltage in millivolts
+    'uptime': 1441998,       # Uptime in seconds
+    'last_rssi': -63,        # RSSI of last received packet (dBm)
+    'last_snr': 12.5,        # SNR of last received packet (dB)
+    'noise_floor': -118,     # Noise floor in dBm
+    'tx_queue_len': 0,       # TX queue depth
+    'nb_recv': 221311,       # Total packets received (counter)
+    'nb_sent': 93993,        # Total packets sent (counter)
+    'airtime': 64461,        # TX airtime in seconds (counter)
+    'rx_airtime': 146626,    # RX airtime in seconds (counter)
+    'flood_dups': 59799,     # Duplicate flood packets (counter)
+    'direct_dups': 8,        # Duplicate direct packets (counter)
+    'sent_flood': 92207,     # Flood packets transmitted (counter)
+    'recv_flood': 216960,    # Flood packets received (counter)
+    'sent_direct': 1786,     # Direct packets transmitted (counter)
+    'recv_direct': 4328      # Direct packets received (counter)
+}
+```
+
+---
+
+## Derived Metrics
+
+These are computed at query time, not stored:
+
+| Metric | Source | Computation |
+|--------|--------|-------------|
+| `bat_pct` | `bat` or `battery_mv` | `voltage_to_percentage(mv / 1000)` using 18650 Li-ion discharge curve |
+
+---
+
+## Notes
+
+- **Counters** reset to 0 on device reboot
+- **Millivolts to volts**: Divide by 1000 (e.g., `bat: 4047` → `4.047V`)
+- Repeater fields come from a single `req_status_sync()` call
+- Companion fields are spread across multiple `get_stats_*()` calls

--- a/src/meshmon/db.py
+++ b/src/meshmon/db.py
@@ -1,14 +1,14 @@
 """SQLite database for metrics storage.
 
-This module replaces JSON snapshot storage with a SQLite database
-for faster chart rendering and report generation.
+This module provides EAV (Entity-Attribute-Value) storage for metrics
+from MeshCore devices. Firmware field names are stored directly for
+future-proofing - new fields are captured automatically without schema changes.
 
 Schema design:
-- Two tables: companion_metrics, repeater_metrics
-- timestamp as primary key (WITHOUT ROWID for compact storage)
-- STRICT mode for type safety
-- Pre-computed bat_pct at insert time
-- Raw counter values stored (rates computed in queries)
+- Single 'metrics' table with (ts, role, metric, value) structure
+- Firmware field names stored as-is (e.g., 'bat', 'nb_recv', 'battery_mv')
+- bat_pct computed at query time from voltage values
+- Raw counter values stored (rates computed during chart rendering)
 
 Migration system:
 - Schema version tracked in db_meta table
@@ -18,6 +18,7 @@ Migration system:
 """
 
 import sqlite3
+from collections import defaultdict
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Iterator, Optional
@@ -32,6 +33,12 @@ MIGRATIONS_DIR = Path(__file__).parent / "migrations"
 
 # Valid role values (used to prevent SQL injection)
 VALID_ROLES = ("companion", "repeater")
+
+# Battery voltage field names by role (for bat_pct derivation)
+BATTERY_FIELD = {
+    "companion": "battery_mv",
+    "repeater": "bat",
+}
 
 
 def _validate_role(role: str) -> str:
@@ -242,122 +249,99 @@ def get_connection(
         conn.close()
 
 
-def insert_companion_metrics(
+# =============================================================================
+# Metric Insert Functions (EAV)
+# =============================================================================
+
+
+def insert_metric(
     ts: int,
-    bat_v: Optional[float] = None,
-    contacts: Optional[int] = None,
-    uptime: Optional[int] = None,
-    rx: Optional[int] = None,
-    tx: Optional[int] = None,
+    role: str,
+    metric: str,
+    value: float,
     db_path: Optional[Path] = None,
 ) -> bool:
-    """Insert companion metrics row.
-
-    Pre-computes bat_pct from bat_v at insert time.
+    """Insert a single metric value.
 
     Args:
         ts: Unix timestamp
-        bat_v: Battery voltage in volts
-        contacts: Contact count
-        uptime: Uptime in seconds
-        rx: Total packets received (counter)
-        tx: Total packets sent (counter)
+        role: 'companion' or 'repeater'
+        metric: Firmware field name (e.g., 'bat', 'nb_recv')
+        value: Metric value
         db_path: Optional path override
 
     Returns:
-        True if inserted, False if duplicate timestamp
+        True if inserted, False if duplicate (ts, role, metric)
     """
-    # Pre-compute bat_pct
-    bat_pct = voltage_to_percentage(bat_v) if bat_v is not None else None
+    role = _validate_role(role)
 
     try:
         with get_connection(db_path) as conn:
             conn.execute(
-                """
-                INSERT INTO companion_metrics
-                (ts, bat_v, bat_pct, contacts, uptime, rx, tx)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
-                """,
-                (ts, bat_v, bat_pct, contacts, uptime, rx, tx)
+                "INSERT INTO metrics (ts, role, metric, value) VALUES (?, ?, ?, ?)",
+                (ts, role, metric, value)
             )
         return True
     except sqlite3.IntegrityError as e:
         if "UNIQUE constraint failed" in str(e) or "PRIMARY KEY" in str(e):
-            log.debug(f"Duplicate companion timestamp: {ts}")
+            log.debug(f"Duplicate metric: ts={ts}, role={role}, metric={metric}")
             return False
-        raise  # Re-raise other integrity errors
+        raise
 
 
-def insert_repeater_metrics(
+def insert_metrics(
     ts: int,
-    bat_v: Optional[float] = None,
-    rssi: Optional[int] = None,
-    snr: Optional[float] = None,
-    uptime: Optional[int] = None,
-    noise: Optional[int] = None,
-    txq: Optional[int] = None,
-    rx: Optional[int] = None,
-    tx: Optional[int] = None,
-    airtime: Optional[int] = None,
-    rx_air: Optional[int] = None,
-    fl_dups: Optional[int] = None,
-    di_dups: Optional[int] = None,
-    fl_tx: Optional[int] = None,
-    fl_rx: Optional[int] = None,
-    di_tx: Optional[int] = None,
-    di_rx: Optional[int] = None,
+    role: str,
+    metrics: dict[str, Any],
     db_path: Optional[Path] = None,
-) -> bool:
-    """Insert repeater metrics row.
+) -> int:
+    """Insert multiple metrics from a dict (e.g., firmware status response).
 
-    Pre-computes bat_pct from bat_v at insert time.
+    Only numeric values (int, float) are inserted. Non-numeric values are skipped.
 
     Args:
         ts: Unix timestamp
-        bat_v: Battery voltage in volts
-        rssi: Signal strength (dBm)
-        snr: Signal-to-noise ratio (dB)
-        uptime: Uptime in seconds
-        noise: Noise floor (dBm)
-        txq: TX queue depth
-        rx: Total packets received (counter)
-        tx: Total packets sent (counter)
-        airtime: TX airtime seconds (counter)
-        rx_air: RX airtime seconds (counter)
-        fl_dups: Flood duplicates (counter)
-        di_dups: Direct duplicates (counter)
-        fl_tx: Flood TX packets (counter)
-        fl_rx: Flood RX packets (counter)
-        di_tx: Direct TX packets (counter)
-        di_rx: Direct RX packets (counter)
+        role: 'companion' or 'repeater'
+        metrics: Dict of metric_name -> value (from firmware response)
         db_path: Optional path override
 
     Returns:
-        True if inserted, False if duplicate timestamp
+        Number of metrics inserted
     """
-    # Pre-compute bat_pct
-    bat_pct = voltage_to_percentage(bat_v) if bat_v is not None else None
+    role = _validate_role(role)
+    inserted = 0
 
     try:
         with get_connection(db_path) as conn:
-            conn.execute(
-                """
-                INSERT INTO repeater_metrics
-                (ts, bat_v, bat_pct, rssi, snr, uptime, noise, txq,
-                 rx, tx, airtime, rx_air, fl_dups, di_dups,
-                 fl_tx, fl_rx, di_tx, di_rx)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (ts, bat_v, bat_pct, rssi, snr, uptime, noise, txq,
-                 rx, tx, airtime, rx_air, fl_dups, di_dups,
-                 fl_tx, fl_rx, di_tx, di_rx)
-            )
-        return True
-    except sqlite3.IntegrityError as e:
-        if "UNIQUE constraint failed" in str(e) or "PRIMARY KEY" in str(e):
-            log.debug(f"Duplicate repeater timestamp: {ts}")
-            return False
-        raise  # Re-raise other integrity errors
+            for metric, value in metrics.items():
+                # Only insert numeric values
+                if not isinstance(value, (int, float)):
+                    continue
+                # Skip None values
+                if value is None:
+                    continue
+
+                try:
+                    conn.execute(
+                        "INSERT INTO metrics (ts, role, metric, value) VALUES (?, ?, ?, ?)",
+                        (ts, role, metric, float(value))
+                    )
+                    inserted += 1
+                except sqlite3.IntegrityError:
+                    # Duplicate, skip
+                    pass
+
+        log.debug(f"Inserted {inserted} metrics for {role} at ts={ts}")
+        return inserted
+
+    except Exception as e:
+        log.error(f"Failed to insert metrics: {e}")
+        raise
+
+
+# =============================================================================
+# Metric Query Functions (EAV)
+# =============================================================================
 
 
 def get_metrics_for_period(
@@ -365,8 +349,11 @@ def get_metrics_for_period(
     start_ts: int,
     end_ts: int,
     db_path: Optional[Path] = None,
-) -> list[dict[str, Any]]:
+) -> dict[str, list[tuple[int, float]]]:
     """Fetch all metrics for a role within a time range.
+
+    Returns data pivoted by metric name for easy chart rendering.
+    Also computes bat_pct from battery voltage if available.
 
     Args:
         role: "companion" or "repeater"
@@ -375,58 +362,102 @@ def get_metrics_for_period(
         db_path: Optional path override
 
     Returns:
-        List of metric rows as dicts
+        Dict mapping metric names to list of (timestamp, value) tuples,
+        sorted by timestamp ascending.
 
     Raises:
         ValueError: If role is not valid
     """
     role = _validate_role(role)
-    table = f"{role}_metrics"
 
     with get_connection(db_path, readonly=True) as conn:
         cursor = conn.execute(
-            f"""
-            SELECT * FROM {table}
-            WHERE ts BETWEEN ? AND ?
+            """
+            SELECT ts, metric, value
+            FROM metrics
+            WHERE role = ? AND ts BETWEEN ? AND ?
             ORDER BY ts ASC
             """,
-            (start_ts, end_ts)
+            (role, start_ts, end_ts)
         )
-        return [dict(row) for row in cursor.fetchall()]
+
+        result: dict[str, list[tuple[int, float]]] = defaultdict(list)
+        for row in cursor:
+            if row["value"] is not None:
+                result[row["metric"]].append((row["ts"], row["value"]))
+
+        # Compute bat_pct from battery voltage
+        bat_field = BATTERY_FIELD.get(role)
+        if bat_field and bat_field in result:
+            bat_pct_data = []
+            for ts, mv in result[bat_field]:
+                voltage = mv / 1000.0  # Convert millivolts to volts
+                pct = voltage_to_percentage(voltage)
+                if pct is not None:
+                    bat_pct_data.append((ts, pct))
+            if bat_pct_data:
+                result["bat_pct"] = bat_pct_data
+
+        return dict(result)
 
 
 def get_latest_metrics(
     role: str,
     db_path: Optional[Path] = None,
 ) -> Optional[dict[str, Any]]:
-    """Get the most recent metrics row for a role.
+    """Get the most recent metrics for a role.
+
+    Returns all metrics at the most recent timestamp as a flat dict.
+    Also computes bat_pct from battery voltage.
 
     Args:
         role: "companion" or "repeater"
         db_path: Optional path override
 
     Returns:
-        Most recent row as dict, or None if no data
+        Dict with 'ts' and all metric values, or None if no data
 
     Raises:
         ValueError: If role is not valid
     """
     role = _validate_role(role)
-    table = f"{role}_metrics"
 
     with get_connection(db_path, readonly=True) as conn:
+        # Find the most recent timestamp for this role
         cursor = conn.execute(
-            f"SELECT * FROM {table} ORDER BY ts DESC LIMIT 1"
+            "SELECT MAX(ts) as max_ts FROM metrics WHERE role = ?",
+            (role,)
         )
         row = cursor.fetchone()
-        return dict(row) if row else None
+        if not row or row["max_ts"] is None:
+            return None
+
+        max_ts = row["max_ts"]
+
+        # Get all metrics at that timestamp
+        cursor = conn.execute(
+            "SELECT metric, value FROM metrics WHERE role = ? AND ts = ?",
+            (role, max_ts)
+        )
+
+        result: dict[str, Any] = {"ts": max_ts}
+        for row in cursor:
+            result[row["metric"]] = row["value"]
+
+        # Compute bat_pct from battery voltage
+        bat_field = BATTERY_FIELD.get(role)
+        if bat_field and bat_field in result:
+            voltage = result[bat_field] / 1000.0
+            result["bat_pct"] = voltage_to_percentage(voltage)
+
+        return result
 
 
 def get_metric_count(
     role: str,
     db_path: Optional[Path] = None,
 ) -> int:
-    """Get total row count for a role.
+    """Get total number of metric rows for a role.
 
     Args:
         role: "companion" or "repeater"
@@ -439,11 +470,63 @@ def get_metric_count(
         ValueError: If role is not valid
     """
     role = _validate_role(role)
-    table = f"{role}_metrics"
 
     with get_connection(db_path, readonly=True) as conn:
-        cursor = conn.execute(f"SELECT COUNT(*) FROM {table}")
+        cursor = conn.execute(
+            "SELECT COUNT(*) FROM metrics WHERE role = ?",
+            (role,)
+        )
         return cursor.fetchone()[0]
+
+
+def get_distinct_timestamps(
+    role: str,
+    db_path: Optional[Path] = None,
+) -> int:
+    """Get count of distinct timestamps for a role.
+
+    Useful for understanding actual sample count (vs metric row count).
+
+    Args:
+        role: "companion" or "repeater"
+        db_path: Optional path override
+
+    Returns:
+        Number of distinct timestamps
+    """
+    role = _validate_role(role)
+
+    with get_connection(db_path, readonly=True) as conn:
+        cursor = conn.execute(
+            "SELECT COUNT(DISTINCT ts) FROM metrics WHERE role = ?",
+            (role,)
+        )
+        return cursor.fetchone()[0]
+
+
+def get_available_metrics(
+    role: str,
+    db_path: Optional[Path] = None,
+) -> list[str]:
+    """Get list of all metric names stored for a role.
+
+    Useful for discovering what metrics are available from firmware.
+
+    Args:
+        role: "companion" or "repeater"
+        db_path: Optional path override
+
+    Returns:
+        List of metric names
+    """
+    role = _validate_role(role)
+
+    with get_connection(db_path, readonly=True) as conn:
+        cursor = conn.execute(
+            "SELECT DISTINCT metric FROM metrics WHERE role = ? ORDER BY metric",
+            (role,)
+        )
+        return [row["metric"] for row in cursor]
 
 
 def vacuum_db(db_path: Optional[Path] = None) -> None:

--- a/src/meshmon/migrations/002_eav_schema.sql
+++ b/src/meshmon/migrations/002_eav_schema.sql
@@ -1,0 +1,97 @@
+-- Migration 002: EAV metrics schema
+-- Replaces wide companion_metrics and repeater_metrics tables with
+-- a single flexible Entity-Attribute-Value pattern.
+--
+-- Benefits:
+-- - New firmware fields automatically captured without schema changes
+-- - Firmware field renames only require Python config updates
+-- - Unified query interface for all metrics
+--
+-- Trade-offs:
+-- - More rows (~3.75M/year vs ~560K/year)
+-- - Queries filter by metric name instead of column access
+-- - All values stored as REAL (no per-column type safety)
+
+-- Create new EAV metrics table
+CREATE TABLE metrics (
+    ts INTEGER NOT NULL,
+    role TEXT NOT NULL,            -- 'companion' or 'repeater'
+    metric TEXT NOT NULL,          -- Firmware field name (e.g., 'bat', 'nb_recv')
+    value REAL,                    -- Metric value
+    PRIMARY KEY (ts, role, metric)
+) STRICT, WITHOUT ROWID;
+
+-- Index for common query pattern: get all metrics for a role in time range
+-- Primary key covers (ts, role, metric) but this helps when filtering by role first
+CREATE INDEX idx_metrics_role_ts ON metrics(role, ts);
+
+-- Migrate companion data to firmware field names
+-- Note: bat_v stored as volts, convert back to millivolts (battery_mv)
+INSERT INTO metrics (ts, role, metric, value)
+SELECT ts, 'companion', 'battery_mv', bat_v * 1000 FROM companion_metrics WHERE bat_v IS NOT NULL;
+
+INSERT INTO metrics (ts, role, metric, value)
+SELECT ts, 'companion', 'uptime_secs', uptime FROM companion_metrics WHERE uptime IS NOT NULL;
+
+INSERT INTO metrics (ts, role, metric, value)
+SELECT ts, 'companion', 'contacts', contacts FROM companion_metrics WHERE contacts IS NOT NULL;
+
+INSERT INTO metrics (ts, role, metric, value)
+SELECT ts, 'companion', 'recv', rx FROM companion_metrics WHERE rx IS NOT NULL;
+
+INSERT INTO metrics (ts, role, metric, value)
+SELECT ts, 'companion', 'sent', tx FROM companion_metrics WHERE tx IS NOT NULL;
+
+-- Migrate repeater data to firmware field names
+-- Note: bat_v stored as volts, convert back to millivolts (bat)
+INSERT INTO metrics (ts, role, metric, value)
+SELECT ts, 'repeater', 'bat', bat_v * 1000 FROM repeater_metrics WHERE bat_v IS NOT NULL;
+
+INSERT INTO metrics (ts, role, metric, value)
+SELECT ts, 'repeater', 'uptime', uptime FROM repeater_metrics WHERE uptime IS NOT NULL;
+
+INSERT INTO metrics (ts, role, metric, value)
+SELECT ts, 'repeater', 'last_rssi', rssi FROM repeater_metrics WHERE rssi IS NOT NULL;
+
+INSERT INTO metrics (ts, role, metric, value)
+SELECT ts, 'repeater', 'last_snr', snr FROM repeater_metrics WHERE snr IS NOT NULL;
+
+INSERT INTO metrics (ts, role, metric, value)
+SELECT ts, 'repeater', 'noise_floor', noise FROM repeater_metrics WHERE noise IS NOT NULL;
+
+INSERT INTO metrics (ts, role, metric, value)
+SELECT ts, 'repeater', 'tx_queue_len', txq FROM repeater_metrics WHERE txq IS NOT NULL;
+
+INSERT INTO metrics (ts, role, metric, value)
+SELECT ts, 'repeater', 'nb_recv', rx FROM repeater_metrics WHERE rx IS NOT NULL;
+
+INSERT INTO metrics (ts, role, metric, value)
+SELECT ts, 'repeater', 'nb_sent', tx FROM repeater_metrics WHERE tx IS NOT NULL;
+
+INSERT INTO metrics (ts, role, metric, value)
+SELECT ts, 'repeater', 'airtime', airtime FROM repeater_metrics WHERE airtime IS NOT NULL;
+
+INSERT INTO metrics (ts, role, metric, value)
+SELECT ts, 'repeater', 'rx_airtime', rx_air FROM repeater_metrics WHERE rx_air IS NOT NULL;
+
+INSERT INTO metrics (ts, role, metric, value)
+SELECT ts, 'repeater', 'flood_dups', fl_dups FROM repeater_metrics WHERE fl_dups IS NOT NULL;
+
+INSERT INTO metrics (ts, role, metric, value)
+SELECT ts, 'repeater', 'direct_dups', di_dups FROM repeater_metrics WHERE di_dups IS NOT NULL;
+
+INSERT INTO metrics (ts, role, metric, value)
+SELECT ts, 'repeater', 'sent_flood', fl_tx FROM repeater_metrics WHERE fl_tx IS NOT NULL;
+
+INSERT INTO metrics (ts, role, metric, value)
+SELECT ts, 'repeater', 'recv_flood', fl_rx FROM repeater_metrics WHERE fl_rx IS NOT NULL;
+
+INSERT INTO metrics (ts, role, metric, value)
+SELECT ts, 'repeater', 'sent_direct', di_tx FROM repeater_metrics WHERE di_tx IS NOT NULL;
+
+INSERT INTO metrics (ts, role, metric, value)
+SELECT ts, 'repeater', 'recv_direct', di_rx FROM repeater_metrics WHERE di_rx IS NOT NULL;
+
+-- Drop old wide tables
+DROP TABLE companion_metrics;
+DROP TABLE repeater_metrics;


### PR DESCRIPTION
## Summary

- Migrates from wide tables (`companion_metrics`, `repeater_metrics`) to a single Entity-Attribute-Value schema
- Stores firmware field names directly (e.g., `bat`, `nb_recv`, `battery_mv`) for future-proofing
- New metrics are captured automatically without schema changes
- `bat_pct` computed at query time from voltage values using 18650 discharge curve

## Changes

**Database:**
- New `metrics` table with `(ts, role, metric, value)` structure
- Migration `002_eav_schema.sql` converts existing data and drops old tables

**Collectors:**
- `phase1_collect_companion.py`: Simplified to insert all numeric metrics from firmware responses
- `phase1_collect_repeater.py`: Simplified to insert all numeric metrics from firmware responses

**Rendering:**
- `charts.py`: Updated to query EAV data, pivot by metric name
- `html.py`: Updated report table builders to use firmware field names
- `reports.py`: Updated to use firmware field names with mV→V conversion

**Configuration:**
- `metrics.py`: Centralized `MetricConfig` with display names, units, scale factors, counter/gauge type
- Firmware field names used throughout instead of display names

**Documentation:**
- `CLAUDE.md`: Updated schema documentation and metric references
- `docs/firmware-responses.md`: Documents actual firmware response structures

## Test plan

- [x] Full render pipeline verified: 184 charts, 8 site pages, all reports
- [x] HTML reports display all metrics correctly (battery voltage, RSSI, packet counts, etc.)
- [x] TXT/JSON reports generate with correct values
- [x] No old metric names remaining in codebase (verified via grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)