### PR TITLE
feat: add telemetry collection for companion and repeater nodes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,8 @@ Always edit the source templates, then regenerate with `python scripts/render_si
 
 ## Running Commands
 
+**IMPORTANT: Always activate the virtual environment before running any Python commands.**
+
 ```bash
 cd /path/to/meshcore-stats
 source .venv/bin/activate
@@ -354,10 +356,16 @@ All configuration via `meshcore.conf` or environment variables. The config file 
 
 ### Timeouts & Retry
 - `REMOTE_TIMEOUT_S`: Minimum timeout for LoRa requests (default: 10)
-- `REMOTE_RETRY_ATTEMPTS`: Number of retry attempts (default: 5)
+- `REMOTE_RETRY_ATTEMPTS`: Number of retry attempts (default: 2)
 - `REMOTE_RETRY_BACKOFF_S`: Seconds between retries (default: 4)
 - `REMOTE_CB_FAILS`: Failures before circuit breaker opens (default: 6)
 - `REMOTE_CB_COOLDOWN_S`: Circuit breaker cooldown (default: 3600)
+
+### Telemetry Collection
+- `TELEMETRY_ENABLED`: Enable environmental telemetry collection from repeater (0/1, default: 0)
+- `TELEMETRY_TIMEOUT_S`: Timeout for telemetry requests (default: 10)
+- `TELEMETRY_RETRY_ATTEMPTS`: Retry attempts for telemetry (default: 2)
+- `TELEMETRY_RETRY_BACKOFF_S`: Backoff between telemetry retries (default: 4)
 
 ### Intervals
 - `COMPANION_STEP`: Collection interval for companion (default: 60s)
@@ -409,6 +417,12 @@ Metrics are classified as either **gauge** or **counter** in `src/meshmon/metric
   - Repeater: `nb_recv`, `nb_sent`, `airtime`, `rx_airtime`, `flood_dups`, `direct_dups`, `sent_flood`, `recv_flood`, `sent_direct`, `recv_direct`
 
 Counter metrics are converted to rates during chart rendering by calculating deltas between consecutive readings.
+
+- **TELEMETRY**: Environmental sensor data (when `TELEMETRY_ENABLED=1`):
+  - Stored with `telemetry.` prefix: `telemetry.temperature.0`, `telemetry.humidity.0`, `telemetry.barometer.0`
+  - Channel number distinguishes multiple sensors of the same type
+  - Compound values (e.g., GPS) stored as: `telemetry.gps.0.latitude`, `telemetry.gps.0.longitude`
+  - Telemetry collection does NOT affect circuit breaker state
 
 ## Database Schema
 

--- a/meshcore.conf.example
+++ b/meshcore.conf.example
@@ -114,6 +114,23 @@ RADIO_CODING_RATE=CR8
 # REMOTE_CB_COOLDOWN_S=3600
 
 # =============================================================================
+# Telemetry Collection (Environmental Sensors)
+# =============================================================================
+# Enable telemetry collection from repeater's environmental sensors
+# (temperature, humidity, barometric pressure, etc.)
+# Requires sensor board attached to repeater (e.g., BME280, BME680)
+# Default: 0 (disabled)
+# TELEMETRY_ENABLED=1
+
+# Telemetry-specific timeout and retry settings
+# Defaults match status settings. Separate config allows tuning if telemetry
+# proves problematic (e.g., firmware doesn't support it, sensor board missing).
+# You can reduce these if telemetry collection is causing issues.
+# TELEMETRY_TIMEOUT_S=10
+# TELEMETRY_RETRY_ATTEMPTS=2
+# TELEMETRY_RETRY_BACKOFF_S=4
+
+# =============================================================================
 # Paths (Native installation only)
 # =============================================================================
 # Docker: Leave these commented. The container uses /data/state and /out by default.

--- a/src/meshmon/env.py
+++ b/src/meshmon/env.py
@@ -155,6 +155,14 @@ class Config:
         self.remote_cb_fails = get_int("REMOTE_CB_FAILS", 6)
         self.remote_cb_cooldown_s = get_int("REMOTE_CB_COOLDOWN_S", 3600)
 
+        # Telemetry collection (requires sensor board on repeater)
+        self.telemetry_enabled = get_bool("TELEMETRY_ENABLED", False)
+        # Separate settings allow tuning if telemetry proves problematic
+        # Defaults match status settings - tune down if needed
+        self.telemetry_timeout_s = get_int("TELEMETRY_TIMEOUT_S", 10)
+        self.telemetry_retry_attempts = get_int("TELEMETRY_RETRY_ATTEMPTS", 2)
+        self.telemetry_retry_backoff_s = get_int("TELEMETRY_RETRY_BACKOFF_S", 4)
+
         # Paths (defaults are Docker container paths; native installs override via config)
         self.state_dir = get_path("STATE_DIR", "/data/state")
         self.out_dir = get_path("OUT_DIR", "/out")

--- a/src/meshmon/telemetry.py
+++ b/src/meshmon/telemetry.py
@@ -1,0 +1,102 @@
+"""Telemetry data extraction from Cayenne LPP format."""
+
+from typing import Any
+from . import log
+
+__all__ = ["extract_lpp_from_payload", "extract_telemetry_metrics"]
+
+
+def extract_lpp_from_payload(payload: Any) -> list | None:
+    """Extract LPP data list from telemetry payload.
+
+    Handles both formats returned by the MeshCore API:
+    - Dict format: {'pubkey_pre': '...', 'lpp': [...]}
+    - Direct list format: [...]
+
+    Args:
+        payload: Raw telemetry payload from get_self_telemetry() or req_telemetry_sync()
+
+    Returns:
+        The LPP data list, or None if not extractable.
+    """
+    if payload is None:
+        return None
+
+    if isinstance(payload, dict):
+        lpp = payload.get("lpp")
+        if lpp is None:
+            log.debug("No 'lpp' key in telemetry payload dict")
+            return None
+        if not isinstance(lpp, list):
+            log.debug(f"Unexpected LPP data type in payload: {type(lpp).__name__}")
+            return None
+        return lpp
+
+    if isinstance(payload, list):
+        return payload
+
+    log.debug(f"Unexpected telemetry payload type: {type(payload).__name__}")
+    return None
+
+
+def extract_telemetry_metrics(lpp_data: Any) -> dict[str, float]:
+    """Extract numeric telemetry values from Cayenne LPP response.
+
+    Expected format:
+    [
+        {"type": "temperature", "channel": 0, "value": 23.5},
+        {"type": "gps", "channel": 1, "value": {"latitude": 51.5, "longitude": -0.1, "altitude": 10}}
+    ]
+
+    Keys are formatted as:
+    - telemetry.{type}.{channel} for scalar values
+    - telemetry.{type}.{channel}.{subkey} for compound values (e.g., GPS)
+
+    Returns:
+        Dict mapping metric keys to float values. Invalid readings are skipped.
+    """
+    if not isinstance(lpp_data, list):
+        log.warn(f"Expected list for LPP data, got {type(lpp_data).__name__}")
+        return {}
+
+    metrics: dict[str, float] = {}
+
+    for i, reading in enumerate(lpp_data):
+        if not isinstance(reading, dict):
+            log.debug(f"Skipping non-dict LPP reading at index {i}")
+            continue
+
+        sensor_type = reading.get("type")
+        if not isinstance(sensor_type, str) or not sensor_type.strip():
+            log.debug(f"Skipping reading with invalid type at index {i}")
+            continue
+
+        # Normalize sensor type for use as metric key component
+        sensor_type = sensor_type.strip().lower().replace(" ", "_")
+
+        channel = reading.get("channel", 0)
+        if not isinstance(channel, int):
+            channel = 0
+
+        value = reading.get("value")
+        base_key = f"telemetry.{sensor_type}.{channel}"
+
+        # Note: Check bool before int because bool is a subclass of int in Python.
+        # Some sensors may report digital on/off values as booleans.
+        if isinstance(value, bool):
+            metrics[base_key] = float(value)
+        elif isinstance(value, (int, float)):
+            metrics[base_key] = float(value)
+        elif isinstance(value, dict):
+            for subkey, subval in value.items():
+                if not isinstance(subkey, str):
+                    continue
+                subkey_clean = subkey.strip().lower().replace(" ", "_")
+                if not subkey_clean:
+                    continue
+                if isinstance(subval, bool):
+                    metrics[f"{base_key}.{subkey_clean}"] = float(subval)
+                elif isinstance(subval, (int, float)):
+                    metrics[f"{base_key}.{subkey_clean}"] = float(subval)
+
+    return metrics


### PR DESCRIPTION
## Summary

- Add environmental telemetry collection (temperature, humidity, barometric pressure, voltage) from both nodes
- Store telemetry in the same EAV metrics table with `telemetry.` prefix (e.g., `telemetry.voltage.1`)
- Feature flag `TELEMETRY_ENABLED` defaults to OFF

## Changes

| File | Change |
|------|--------|
| `src/meshmon/telemetry.py` | NEW - Shared module with `extract_lpp_from_payload()` and `extract_telemetry_metrics()` helpers |
| `src/meshmon/env.py` | Add telemetry config options |
| `scripts/collect_companion.py` | Process and store telemetry from `get_self_telemetry()` |
| `scripts/collect_repeater.py` | Process and store telemetry from `req_telemetry_sync()` |
| `meshcore.conf.example` | Document telemetry configuration |
| `docs/firmware-responses.md` | Document payload format and API |

## Key Design Decisions

1. **Payload format handling**: MeshCore API returns `{'pubkey_pre': '...', 'lpp': [...]}` - shared helper extracts `lpp` list
2. **LoRa reliability**: Repeater stores status metrics BEFORE attempting telemetry (critical data safe even if telemetry fails)
3. **Circuit breaker**: Telemetry failures do NOT affect circuit breaker state (status success proves link is up)
4. **Separate config**: Telemetry has its own timeout/retry settings that can be tuned independently

## Test plan

- [x] Companion with `TELEMETRY_ENABLED=0` - no telemetry extracted
- [x] Companion with `TELEMETRY_ENABLED=1` - telemetry extracted and stored
- [x] Repeater with `TELEMETRY_ENABLED=0` - no telemetry extracted  
- [x] Repeater with `TELEMETRY_ENABLED=1` - telemetry extracted and stored
- [x] Database shows `telemetry.voltage.1` for both nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)