### PR TITLE
fix(docker): avoid uv project install during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ ENV PATH="/opt/venv/bin:$PATH" \
 # Install Python dependencies
 COPY pyproject.toml uv.lock ./
 RUN pip install --no-cache-dir --upgrade pip uv && \
-    uv sync --frozen --no-dev
+    uv sync --frozen --no-dev --no-install-project
 
 # =============================================================================
 # Stage 2: Runtime


### PR DESCRIPTION
## Summary
- prevent uv from trying to install the project before source is copied
- keep dependency sync frozen and production-only

## Testing
- not run (Docker build change only)