### PR TITLE
chore: adopt Renovate and pin uv image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -197,7 +197,7 @@ jobs:
       # Vulnerability scanning
       - name: Run Trivy vulnerability scanner
         if: "!(github.event_name == 'schedule' && steps.get-version.outputs.skip == 'true')"
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.image-tag.outputs.tag }}
           format: "sarif"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,7 +369,7 @@ Jobs configured in `docker/ofelia.ini`:
 
 **Nightly rebuilds** ensure version tags always include the latest OS security patches. This is a common pattern used by official Docker images (nginx, postgres, node). Users needing reproducibility should pin by SHA digest or use dated nightly tags.
 
-All GitHub Actions are pinned by full SHA for security. Dependabot can be configured to update these automatically.
+All GitHub Actions are pinned by full SHA for security. Renovate is configured in `renovate.json` to update dependencies and maintain lockfiles.
 
 The test and lint workflow (`.github/workflows/test.yml`) installs dependencies with uv (`uv sync --locked --extra dev`) and runs commands via `uv run`, using `uv.lock` as the source of truth.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
 # =============================================================================
+# Stage 0: uv binary
+# =============================================================================
+FROM ghcr.io/astral-sh/uv:0.9.9@sha256:f6e3549ed287fee0ddde2460a2a74a2d74366f84b04aaa34c1f19fec40da8652 AS uv
+
+# =============================================================================
 # Stage 1: Build dependencies
 # =============================================================================
 FROM python:3.12-slim-bookworm AS builder
@@ -37,9 +42,12 @@ RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH" \
     UV_PROJECT_ENVIRONMENT=/opt/venv
 
+# Copy uv binary from pinned image
+COPY --from=uv /uv /usr/local/bin/uv
+
 # Install Python dependencies
 COPY pyproject.toml uv.lock ./
-RUN pip install --no-cache-dir --upgrade pip uv && \
+RUN pip install --no-cache-dir --upgrade pip && \
     uv sync --frozen --no-dev --no-install-project
 
 # =============================================================================

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "lockFileMaintenance": {
+    "enabled": true
+  },
+  "dependencyDashboard": true
+}


### PR DESCRIPTION
## Summary
- add Renovate config with lockfile maintenance + dependency dashboard
- pin the uv binary via the official uv image in Docker builds
- fix Trivy action tag comment for Renovate digest lookup
- update AGENTS dependency automation note

## Testing
- not run (config/build changes only)